### PR TITLE
fix: Improve long press tap command with proper duration handling

### DIFF
--- a/skill/scripts/gesture.py
+++ b/skill/scripts/gesture.py
@@ -179,10 +179,11 @@ class GestureController:
         if self.udid:
             cmd.extend(["--udid", self.udid])
 
+        # Add duration parameter for long press
+        cmd.extend(["--duration", str(int(duration * 1000))])
+
         try:
             subprocess.run(cmd, capture_output=True, check=True)
-            # Simulate hold with delay
-            time.sleep(duration)
             return True
         except subprocess.CalledProcessError:
             return False


### PR DESCRIPTION
## Summary

Improves the long press gesture command by properly utilizing IDB's built-in duration parameter instead of simulating with delays.

## Changes

- Add `--duration` parameter to `tap_and_hold()` method in gesture.py
- Convert duration from seconds to milliseconds for IDB compatibility
- Remove unnecessary `time.sleep()` since IDB handles duration natively
- Maintains backward compatibility with existing long press calls

## Testing

- Long press commands now use IDB's native duration parameter
- Conversion formula: `int(duration * 1000)` (e.g., 2.0 seconds = 2000ms)
- Tested with various duration values

## Technical Details

IDB's `idb ui tap` command supports `--duration` parameter in milliseconds:
- Allows precise control over press duration
- More reliable than simulating with delays
- Integrates better with IDB's event handling

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>