### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # iOS Simulator Skill for Claude Code
 
+[![Run in Smithery](https://smithery.ai/badge/skills/conorluddy)](https://smithery.ai/skills?ns=conorluddy&utm_source=github&utm_medium=badge)
+
+
 Production-ready automation for iOS app testing and building. 21 scripts optimized for both human developers and AI agents.
 
 This is basically a Skill version of my XCode MCP: [https://github.com/conorluddy/xc-mcp](https://github.com/conorluddy/xc-mcp)


### PR DESCRIPTION
## Add skill discoverability badge

Your 9 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/conorluddy)](https://smithery.ai/skills?ns=conorluddy&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.