### PR TITLE
Add Core Data / SwiftData model inspector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ios-simulator-skill",
       "source": "./ios-simulator-skill",
-      "description": "21 production-ready scripts for iOS app testing, building, and automation"
+      "description": "22 production-ready scripts for iOS app testing, building, and automation"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code and developers working with this repo
 iOS Simulator Skill is a production-ready Agent Skill providing 21 scripts for iOS app building, testing, and automation. It wraps Apple's `xcrun simctl` and Facebook's `idb` tools with semantic interfaces designed for AI agents and developers.
 
 **Key Statistics:**
-- 21 production scripts (~8,500 lines)
+- 22 production scripts (~8,500 lines)
 - 5 script categories (Build, Navigation, Testing, Permissions, Lifecycle)
 - 6 shared utility modules (~1,400 lines)
 - 100% token-optimized default output
@@ -19,7 +19,7 @@ iOS Simulator Skill is a production-ready Agent Skill providing 21 scripts for i
 ios-simulator-skill/            # Repository root
 ├── ios-simulator-skill/        # Distributable package
 │   ├── SKILL.md               # Entry point (table of contents)
-│   └── scripts/               # 21 production scripts
+│   └── scripts/               # 22 production scripts
 │       ├── build_and_test.py
 │       ├── xcode/             # Xcode integration module
 │       ├── log_monitor.py

--- a/README.md
+++ b/README.md
@@ -88,19 +88,56 @@ When screenshots are needed (visual verification, bug reports, diffs), the skill
 | Find & tap button | 100+ lines | 1 line | 99% |
 | Login flow | 400+ lines | 15 lines | 96% |
 
-### All 21 Scripts
-
-**Build & Development** — `build_and_test.py`, `log_monitor.py`
-
-**Navigation & Interaction** — `screen_mapper.py`, `navigator.py`, `gesture.py`, `keyboard.py`, `app_launcher.py`
-
-**Testing & Analysis** — `accessibility_audit.py`, `visual_diff.py`, `test_recorder.py`, `app_state_capture.py`, `sim_health_check.sh`, `model_inspector.py`
-
-**Permissions & Environment** — `clipboard.py`, `status_bar.py`, `push_notification.py`, `privacy_manager.py`
-
-**Device Lifecycle** — `simctl_boot.py`, `simctl_shutdown.py`, `simctl_create.py`, `simctl_delete.py`, `simctl_erase.py`
+### All 22 Scripts
 
 Every script supports `--help` and `--json`. See **SKILL.md** for the complete reference.
+
+#### Build & Development
+
+| Script | What it does | Key flags |
+|--------|-------------|-----------|
+| `build_and_test.py` | Build Xcode projects, run tests, parse xcresult bundles | `--project`, `--scheme`, `--test`, `--get-errors`, `--get-warnings` |
+| `log_monitor.py` | Real-time log monitoring with severity filtering | `--app`, `--severity`, `--follow`, `--duration` |
+
+#### Navigation & Interaction
+
+| Script | What it does | Key flags |
+|--------|-------------|-----------|
+| `screen_mapper.py` | Analyze current screen, list interactive elements | `--verbose`, `--hints` |
+| `navigator.py` | Find and interact with elements semantically | `--find-text`, `--find-type`, `--find-id`, `--tap`, `--enter-text` |
+| `gesture.py` | Swipes, scrolls, pinches, long press, pull to refresh | `--swipe`, `--scroll`, `--pinch`, `--long-press`, `--refresh` |
+| `keyboard.py` | Text input and hardware button control | `--type`, `--key`, `--button`, `--clear`, `--dismiss` |
+| `app_launcher.py` | Launch, terminate, install, deep link apps | `--launch`, `--terminate`, `--install`, `--open-url`, `--list` |
+
+#### Testing & Analysis
+
+| Script | What it does | Key flags |
+|--------|-------------|-----------|
+| `accessibility_audit.py` | WCAG compliance checking on current screen | `--verbose`, `--output` |
+| `visual_diff.py` | Compare two screenshots for visual changes | `--threshold`, `--output`, `--details` |
+| `test_recorder.py` | Automated test documentation with screenshots | `--test-name`, `--output` |
+| `app_state_capture.py` | Debugging snapshots (screenshot, hierarchy, logs) | `--app-bundle-id`, `--output`, `--log-lines` |
+| `sim_health_check.sh` | Verify environment (Xcode, simctl, IDB, Python) | — |
+| `model_inspector.py` | Inspect Core Data / SwiftData models from project files | `--project-path`, `--raw`, `--show-versions` |
+
+#### Permissions & Environment
+
+| Script | What it does | Key flags |
+|--------|-------------|-----------|
+| `clipboard.py` | Copy text to simulator clipboard for paste testing | `--copy`, `--test-name` |
+| `status_bar.py` | Override status bar (time, battery, network) | `--preset`, `--time`, `--battery-level`, `--clear` |
+| `push_notification.py` | Send simulated push notifications | `--bundle-id`, `--title`, `--body`, `--payload` |
+| `privacy_manager.py` | Grant, revoke, reset app permissions (13 services) | `--bundle-id`, `--grant`, `--revoke`, `--reset` |
+
+#### Device Lifecycle
+
+| Script | What it does | Key flags |
+|--------|-------------|-----------|
+| `simctl_boot.py` | Boot simulators with readiness verification | `--name`, `--wait-ready`, `--timeout`, `--all`, `--type` |
+| `simctl_shutdown.py` | Gracefully shutdown simulators | `--name`, `--verify`, `--all`, `--type` |
+| `simctl_create.py` | Create simulators by device type and OS version | `--device`, `--runtime`, `--list-devices` |
+| `simctl_delete.py` | Delete simulators with safety confirmation | `--name`, `--yes`, `--all`, `--old` |
+| `simctl_erase.py` | Factory reset without deletion | `--name`, `--verify`, `--all`, `--booted` |
 
 ## Evaluation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # iOS Simulator Skill for Claude Code
 
-Production-ready skill for building, testing, and automating iOS apps. 21 scripts optimized for both human developers and AI agents.
+Production-ready skill for building, testing, and automating iOS apps. 22 scripts optimized for both human developers and AI agents.
 
 ## Xcode Build + Simulator Automation
 
@@ -80,7 +80,7 @@ The accessibility tree gives structured data (element types, labels, frames, tap
 
 ### Screenshot Token Optimization
 
-When screenshots are needed (visual verification, bug reports, diffs), the skill automatically resizes and compresses them to minimize token cost. Default output across all 21 scripts is 3-5 lines — 96% reduction vs raw tool output.
+When screenshots are needed (visual verification, bug reports, diffs), the skill automatically resizes and compresses them to minimize token cost. Default output across all 22 scripts is 3-5 lines — 96% reduction vs raw tool output.
 
 | Task | Raw Tools | This Skill | Savings |
 |------|-----------|-----------|---------|
@@ -94,7 +94,7 @@ When screenshots are needed (visual verification, bug reports, diffs), the skill
 
 **Navigation & Interaction** — `screen_mapper.py`, `navigator.py`, `gesture.py`, `keyboard.py`, `app_launcher.py`
 
-**Testing & Analysis** — `accessibility_audit.py`, `visual_diff.py`, `test_recorder.py`, `app_state_capture.py`, `sim_health_check.sh`
+**Testing & Analysis** — `accessibility_audit.py`, `visual_diff.py`, `test_recorder.py`, `app_state_capture.py`, `sim_health_check.sh`, `model_inspector.py`
 
 **Permissions & Environment** — `clipboard.py`, `status_bar.py`, `push_notification.py`, `privacy_manager.py`
 

--- a/ios-simulator-skill/.claude-plugin/plugin.json
+++ b/ios-simulator-skill/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ios-simulator-skill",
   "version": "1.3.0",
-  "description": "21 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
+  "description": "22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
   "author": {
     "name": "Conor Luddy"
   },

--- a/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/SKILL.md
@@ -128,7 +128,8 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
     - Parse .xcdatamodeld packages (entities, attributes, relationships)
     - Detect model versions and current active version
     - Best-effort SwiftData @Model class extraction
-    - Options: `--project-path`, `--core-data-only`, `--swiftdata-only`, `--show-versions`, `--verbose`, `--json`
+    - Raw source dump for any model on demand (`--raw ModelName`)
+    - Options: `--project-path`, `--core-data-only`, `--swiftdata-only`, `--show-versions`, `--raw`, `--verbose`, `--json`
 
 ### Advanced Testing & Permissions (4 scripts)
 

--- a/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ios-simulator-skill
 version: 1.3.0
-description: 21 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
+description: 22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
 ---
 
 # iOS Simulator Skill
@@ -40,7 +40,7 @@ Use this priority:
 
 Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree costs 10–50 tokens in default mode.
 
-## 21 Production Scripts
+## 22 Production Scripts
 
 ### Build & Development (2 scripts)
 
@@ -95,7 +95,7 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
    - Check app state
    - Options: `--launch`, `--terminate`, `--install`, `--uninstall`, `--open-url`, `--list`, `--state`, `--json`
 
-### Testing & Analysis (5 scripts)
+### Testing & Analysis (6 scripts)
 
 8. **accessibility_audit.py** - Check WCAG compliance on current screen
    - Critical issues (missing labels, empty buttons, no alt text)
@@ -124,25 +124,31 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
     - List available and booted simulators
     - Verify Python packages (Pillow)
 
+13. **model_inspector.py** - Inspect Core Data and SwiftData models from project files
+    - Parse .xcdatamodeld packages (entities, attributes, relationships)
+    - Detect model versions and current active version
+    - Best-effort SwiftData @Model class extraction
+    - Options: `--project-path`, `--core-data-only`, `--swiftdata-only`, `--show-versions`, `--verbose`, `--json`
+
 ### Advanced Testing & Permissions (4 scripts)
 
-13. **clipboard.py** - Manage simulator clipboard for paste testing
+14. **clipboard.py** - Manage simulator clipboard for paste testing
     - Copy text to clipboard
     - Test paste flows without manual entry
     - Options: `--copy`, `--test-name`, `--expected`, `--json`
 
-14. **status_bar.py** - Override simulator status bar appearance
+15. **status_bar.py** - Override simulator status bar appearance
     - Presets: clean (9:41, 100% battery), testing (11:11, 50%), low-battery (20%), airplane (offline)
     - Custom time, network, battery, WiFi settings
     - Options: `--preset`, `--time`, `--data-network`, `--battery-level`, `--clear`, `--json`
 
-15. **push_notification.py** - Send simulated push notifications
+16. **push_notification.py** - Send simulated push notifications
     - Simple mode (title + body + badge)
     - Custom JSON payloads
     - Test notification handling and deep links
     - Options: `--bundle-id`, `--title`, `--body`, `--badge`, `--payload`, `--json`
 
-16. **privacy_manager.py** - Grant, revoke, and reset app permissions
+17. **privacy_manager.py** - Grant, revoke, and reset app permissions
     - 13 supported services (camera, microphone, location, contacts, photos, calendar, health, etc.)
     - Batch operations (comma-separated services)
     - Audit trail with test scenario tracking
@@ -150,34 +156,34 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
 
 ### Device Lifecycle Management (5 scripts)
 
-17. **simctl_boot.py** - Boot simulators with optional readiness verification
+18. **simctl_boot.py** - Boot simulators with optional readiness verification
     - Boot by UDID or device name
     - Wait for device ready with timeout
     - Batch boot operations (--all, --type)
     - Performance timing
     - Options: `--udid`, `--name`, `--wait-ready`, `--timeout`, `--all`, `--type`, `--json`
 
-18. **simctl_shutdown.py** - Gracefully shutdown simulators
+19. **simctl_shutdown.py** - Gracefully shutdown simulators
     - Shutdown by UDID or device name
     - Optional verification of shutdown completion
     - Batch shutdown operations
     - Options: `--udid`, `--name`, `--verify`, `--timeout`, `--all`, `--type`, `--json`
 
-19. **simctl_create.py** - Create simulators dynamically
+20. **simctl_create.py** - Create simulators dynamically
     - Create by device type and iOS version
     - List available device types and runtimes
     - Custom device naming
     - Returns UDID for CI/CD integration
     - Options: `--device`, `--runtime`, `--name`, `--list-devices`, `--list-runtimes`, `--json`
 
-20. **simctl_delete.py** - Permanently delete simulators
+21. **simctl_delete.py** - Permanently delete simulators
     - Delete by UDID or device name
     - Safety confirmation by default (skip with --yes)
     - Batch delete operations
     - Smart deletion (--old N to keep N per device type)
     - Options: `--udid`, `--name`, `--yes`, `--all`, `--type`, `--old`, `--json`
 
-21. **simctl_erase.py** - Factory reset simulators without deletion
+22. **simctl_erase.py** - Factory reset simulators without deletion
     - Preserve device UUID (faster than delete+create)
     - Erase all, by type, or booted simulators
     - Optional verification

--- a/ios-simulator-skill/scripts/model_inspector.py
+++ b/ios-simulator-skill/scripts/model_inspector.py
@@ -210,11 +210,14 @@ class ModelInspector:
         models = []
         swift_files = sorted(self.project_path.rglob("*.swift"))
 
-        # Skip common non-source directories
-        skip_dirs = {".build", "DerivedData", "Pods", "Carthage", ".git"}
+        # Skip common non-source directories and any dotdirs (e.g. .archived, .build, .git)
+        skip_dirs = {"DerivedData", "Pods", "Carthage"}
 
         for swift_file in swift_files:
-            if any(skip in swift_file.parts for skip in skip_dirs):
+            if any(
+                part in skip_dirs or part.startswith(".")
+                for part in swift_file.relative_to(self.project_path).parts
+            ):
                 continue
 
             try:
@@ -311,11 +314,13 @@ class ModelInspector:
 
         for match in prop_pattern.finditer(body):
             name = match.group(1)
-            prop_type = match.group(2).strip()
+            # Strip trailing inline comments (// ...)
+            prop_type = re.sub(r"\s*//.*$", "", match.group(2)).strip()
 
-            # Skip if this line is inside a @Relationship (handled separately)
+            # Skip if preceded by @Relationship on current or previous line
             line_start = body.rfind("\n", 0, match.start()) + 1
-            preceding = body[max(0, line_start - 50) : match.start()]
+            prev_line_start = body.rfind("\n", 0, max(0, line_start - 1)) + 1
+            preceding = body[prev_line_start : match.start()]
             if "@Relationship" in preceding:
                 continue
 
@@ -340,7 +345,7 @@ class ModelInspector:
 
         for match in rel_pattern.finditer(body):
             name = match.group(1)
-            rel_type = match.group(2).strip()
+            rel_type = re.sub(r"\s*//.*$", "", match.group(2)).strip()
             to_many = rel_type.startswith("[") or "Array<" in rel_type
 
             relationships.append(

--- a/ios-simulator-skill/scripts/model_inspector.py
+++ b/ios-simulator-skill/scripts/model_inspector.py
@@ -67,6 +67,83 @@ class ModelInspector:
         has_results = bool(results["core_data"]) or bool(results["swiftdata"])
         return has_results, results
 
+    # === RAW SOURCE EXTRACTION ===
+
+    def get_raw_source(self, model_name: str) -> tuple[bool, str]:
+        """Get raw source for a named model.
+
+        Searches SwiftData @Model classes first, then Core Data XML entities.
+
+        Args:
+            model_name: Class or entity name to look up
+
+        Returns:
+            (success, raw_source) tuple
+        """
+        # Search SwiftData files
+        swift_files = sorted(self.project_path.rglob("*.swift"))
+        skip_dirs = {"DerivedData", "Pods", "Carthage"}
+
+        model_pattern = re.compile(
+            r"@Model\s*\n\s*(?:final\s+)?class\s+(\w+)",
+            re.MULTILINE,
+        )
+
+        for swift_file in swift_files:
+            if any(
+                part in skip_dirs or part.startswith(".")
+                for part in swift_file.relative_to(self.project_path).parts
+            ):
+                continue
+
+            try:
+                content = swift_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            for match in model_pattern.finditer(content):
+                if match.group(1) == model_name:
+                    class_start = match.start()
+                    body = self._extract_class_body(content, match.end())
+                    if body is None:
+                        continue
+                    # Find closing brace position
+                    brace_start = content.find("{", match.end())
+                    depth = 0
+                    end = brace_start
+                    for i in range(brace_start, len(content)):
+                        if content[i] == "{":
+                            depth += 1
+                        elif content[i] == "}":
+                            depth -= 1
+                            if depth == 0:
+                                end = i + 1
+                                break
+                    rel_path = swift_file.relative_to(self.project_path)
+                    raw = content[class_start:end]
+                    return True, f"// {rel_path}\n{raw}"
+
+        # Search Core Data XML
+        for package in self._find_xcdatamodeld():
+            current_version = self._detect_current_version(package)
+            versions = [d for d in package.iterdir() if d.suffix == ".xcdatamodel"]
+            target = current_version or (versions[0].name if versions else None)
+            if not target:
+                continue
+            contents_path = package / target / "contents"
+            if not contents_path.exists():
+                continue
+            try:
+                tree = ElementTree.parse(contents_path)
+            except ElementTree.ParseError:
+                continue
+            for entity_elem in tree.getroot().findall("entity"):
+                if entity_elem.get("name") == model_name:
+                    raw_xml = ElementTree.tostring(entity_elem, encoding="unicode")
+                    return True, f"<!-- {package.name}/{target}/contents -->\n{raw_xml}"
+
+        return False, f"Model '{model_name}' not found"
+
     # === CORE DATA PARSING ===
 
     def _find_xcdatamodeld(self) -> list[Path]:
@@ -495,6 +572,7 @@ Examples:
   python scripts/model_inspector.py --project-path . --json
   python scripts/model_inspector.py --project-path . --show-versions
   python scripts/model_inspector.py --project-path . --core-data-only
+  python scripts/model_inspector.py --project-path . --raw TrainingSession
         """,
     )
 
@@ -519,6 +597,11 @@ Examples:
         action="store_true",
         help="List all model versions with current version highlighted",
     )
+    inspection_group.add_argument(
+        "--raw",
+        metavar="MODEL_NAME",
+        help="Dump raw source for a specific model (Swift class or Core Data entity)",
+    )
 
     output_group = parser.add_argument_group("Output Options")
     output_group.add_argument("--json", action="store_true", help="Output as JSON")
@@ -527,6 +610,16 @@ Examples:
     args = parser.parse_args()
 
     inspector = ModelInspector(project_path=args.project_path)
+
+    if args.raw:
+        success, raw = inspector.get_raw_source(args.raw)
+        if success:
+            print(raw)
+        else:
+            print(f"Error: {raw}", file=sys.stderr)
+            sys.exit(1)
+        return
+
     success, results = inspector.execute(
         core_data_only=args.core_data_only,
         swiftdata_only=args.swiftdata_only,

--- a/ios-simulator-skill/scripts/model_inspector.py
+++ b/ios-simulator-skill/scripts/model_inspector.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""
+Core Data / SwiftData Model Inspector
+
+Parse .xcdatamodeld packages and @Model declarations from project source files.
+Zero external dependencies — uses stdlib xml and regex.
+
+Usage:
+  python scripts/model_inspector.py --project-path /path/to/project
+  python scripts/model_inspector.py --project-path . --verbose
+  python scripts/model_inspector.py --project-path . --json
+  python scripts/model_inspector.py --project-path . --show-versions
+"""
+
+import argparse
+import json
+import plistlib
+import re
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+class ModelInspector:
+    """Inspects Core Data and SwiftData models from project source files."""
+
+    def __init__(self, project_path: str):
+        """Initialize inspector.
+
+        Args:
+            project_path: Path to Xcode project root directory
+        """
+        self.project_path = Path(project_path).resolve()
+
+    def execute(
+        self,
+        *,
+        core_data_only: bool = False,
+        swiftdata_only: bool = False,
+        show_versions: bool = False,
+    ) -> tuple[bool, dict]:
+        """Inspect models and return structured results.
+
+        Args:
+            core_data_only: Skip SwiftData scanning
+            swiftdata_only: Skip Core Data scanning
+            show_versions: Include version history details
+        Returns:
+            (success, results_dict) tuple
+        """
+        if not self.project_path.is_dir():
+            return False, {"error": f"Directory not found: {self.project_path}"}
+
+        results: dict = {"core_data": [], "swiftdata": []}
+
+        if not swiftdata_only:
+            packages = self._find_xcdatamodeld()
+            for package in packages:
+                parsed = self._parse_xcdatamodeld(package, show_versions=show_versions)
+                if parsed:
+                    results["core_data"].append(parsed)
+
+        if not core_data_only:
+            models = self._find_swiftdata_models()
+            results["swiftdata"] = models
+
+        has_results = bool(results["core_data"]) or bool(results["swiftdata"])
+        return has_results, results
+
+    # === CORE DATA PARSING ===
+
+    def _find_xcdatamodeld(self) -> list[Path]:
+        """Find all .xcdatamodeld packages in the project."""
+        return sorted(self.project_path.rglob("*.xcdatamodeld"))
+
+    def _parse_xcdatamodeld(
+        self, package_path: Path, *, show_versions: bool = False
+    ) -> dict | None:
+        """Parse a .xcdatamodeld package into structured data.
+
+        Args:
+            package_path: Path to the .xcdatamodeld directory
+            show_versions: Include all version details
+
+        Returns:
+            Parsed model data or None on error
+        """
+        current_version = self._detect_current_version(package_path)
+        versions = sorted(
+            [d.name for d in package_path.iterdir() if d.suffix == ".xcdatamodel"],
+        )
+
+        result: dict = {
+            "package": package_path.name,
+            "current_version": current_version,
+            "version_count": len(versions),
+            "entities": [],
+        }
+
+        if show_versions:
+            result["versions"] = [{"name": v, "is_current": v == current_version} for v in versions]
+
+        # Parse the current version (or first available)
+        target_version = current_version or (versions[0] if versions else None)
+        if not target_version:
+            return result
+
+        contents_path = package_path / target_version / "contents"
+        if not contents_path.exists():
+            return result
+
+        entities = self._parse_contents_xml(contents_path)
+        result["entities"] = entities
+
+        return result
+
+    def _detect_current_version(self, package_path: Path) -> str | None:
+        """Read .xccurrentversion plist to find active model version.
+
+        Args:
+            package_path: Path to the .xcdatamodeld directory
+
+        Returns:
+            Current version name or None
+        """
+        plist_path = package_path / ".xccurrentversion"
+        if not plist_path.exists():
+            return None
+
+        try:
+            with open(plist_path, "rb") as f:
+                plist = plistlib.load(f)
+            return plist.get("_XCCurrentVersionName")
+        except Exception:
+            return None
+
+    def _parse_contents_xml(self, xml_path: Path) -> list[dict]:
+        """Parse a Core Data contents XML file.
+
+        Args:
+            xml_path: Path to the contents XML file
+
+        Returns:
+            List of entity dicts with attributes, relationships, and fetch requests
+        """
+        try:
+            tree = ElementTree.parse(xml_path)
+        except ElementTree.ParseError:
+            return []
+
+        root = tree.getroot()
+        entities = []
+
+        for entity_elem in root.findall("entity"):
+            entity: dict = {
+                "name": entity_elem.get("name", ""),
+                "is_abstract": entity_elem.get("isAbstract") == "YES",
+                "parent_entity": entity_elem.get("parentEntity"),
+                "represented_class": entity_elem.get("representedClassName"),
+                "attributes": [],
+                "relationships": [],
+                "fetch_requests": [],
+            }
+
+            for attr in entity_elem.findall("attribute"):
+                entity["attributes"].append(
+                    {
+                        "name": attr.get("name", ""),
+                        "type": attr.get("attributeType", ""),
+                        "optional": attr.get("optional") == "YES",
+                        "default_value": attr.get("defaultValueString"),
+                    }
+                )
+
+            for rel in entity_elem.findall("relationship"):
+                entity["relationships"].append(
+                    {
+                        "name": rel.get("name", ""),
+                        "destination": rel.get("destinationEntity", ""),
+                        "to_many": rel.get("toMany") == "YES",
+                        "inverse": rel.get("inverseName"),
+                        "optional": rel.get("optional") == "YES",
+                    }
+                )
+
+            for req in entity_elem.findall("fetchRequest"):
+                entity["fetch_requests"].append(
+                    {
+                        "name": req.get("name", ""),
+                        "predicate": req.get("predicateString", ""),
+                    }
+                )
+
+            # Remove None parent_entity for cleaner output
+            if entity["parent_entity"] is None:
+                del entity["parent_entity"]
+
+            entities.append(entity)
+
+        return entities
+
+    # === SWIFTDATA EXTRACTION ===
+
+    def _find_swiftdata_models(self) -> list[dict]:
+        """Best-effort regex extraction of @Model classes from .swift files.
+
+        Returns:
+            List of detected model dicts
+        """
+        models = []
+        swift_files = sorted(self.project_path.rglob("*.swift"))
+
+        # Skip common non-source directories
+        skip_dirs = {".build", "DerivedData", "Pods", "Carthage", ".git"}
+
+        for swift_file in swift_files:
+            if any(skip in swift_file.parts for skip in skip_dirs):
+                continue
+
+            try:
+                content = swift_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            file_models = self._extract_models_from_swift(content, swift_file)
+            models.extend(file_models)
+
+        return models
+
+    def _extract_models_from_swift(self, content: str, file_path: Path) -> list[dict]:
+        """Extract @Model class declarations from Swift source.
+
+        Args:
+            content: Swift source file content
+            file_path: Path to the source file (for reporting)
+
+        Returns:
+            List of model dicts found in this file
+        """
+        models = []
+
+        # Match @Model decorator followed by class declaration
+        model_pattern = re.compile(
+            r"@Model\s*\n\s*(?:final\s+)?class\s+(\w+)",
+            re.MULTILINE,
+        )
+
+        for match in model_pattern.finditer(content):
+            class_name = match.group(1)
+            class_start = match.end()
+
+            # Find the class body by counting braces
+            body = self._extract_class_body(content, class_start)
+            if body is None:
+                continue
+
+            properties = self._extract_swift_properties(body)
+            relationships = self._extract_swift_relationships(body)
+
+            models.append(
+                {
+                    "class_name": class_name,
+                    "file": str(file_path.relative_to(self.project_path)),
+                    "properties": properties,
+                    "relationships": relationships,
+                }
+            )
+
+        return models
+
+    def _extract_class_body(self, content: str, start: int) -> str | None:
+        """Extract class body by matching braces.
+
+        Args:
+            content: Full file content
+            start: Position after class name
+
+        Returns:
+            Class body string or None if braces don't balance
+        """
+        brace_start = content.find("{", start)
+        if brace_start == -1:
+            return None
+
+        depth = 0
+        for i in range(brace_start, len(content)):
+            if content[i] == "{":
+                depth += 1
+            elif content[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return content[brace_start + 1 : i]
+
+        return None
+
+    def _extract_swift_properties(self, body: str) -> list[dict]:
+        """Extract stored properties from a Swift class body.
+
+        Args:
+            body: Class body content
+
+        Returns:
+            List of property dicts
+        """
+        properties = []
+        # Match var/let declarations (skip computed properties with { get })
+        prop_pattern = re.compile(
+            r"^\s*(?:var|let)\s+(\w+)\s*:\s*([^\n{=]+?)(?:\s*=\s*[^\n]+)?$",
+            re.MULTILINE,
+        )
+
+        for match in prop_pattern.finditer(body):
+            name = match.group(1)
+            prop_type = match.group(2).strip()
+
+            # Skip if this line is inside a @Relationship (handled separately)
+            line_start = body.rfind("\n", 0, match.start()) + 1
+            preceding = body[max(0, line_start - 50) : match.start()]
+            if "@Relationship" in preceding:
+                continue
+
+            properties.append({"name": name, "type": prop_type})
+
+        return properties
+
+    def _extract_swift_relationships(self, body: str) -> list[dict]:
+        """Extract @Relationship properties from a Swift class body.
+
+        Args:
+            body: Class body content
+
+        Returns:
+            List of relationship dicts
+        """
+        relationships = []
+        rel_pattern = re.compile(
+            r"@Relationship[^\n]*\n\s*(?:var|let)\s+(\w+)\s*:\s*([^\n{=]+)",
+            re.MULTILINE,
+        )
+
+        for match in rel_pattern.finditer(body):
+            name = match.group(1)
+            rel_type = match.group(2).strip()
+            to_many = rel_type.startswith("[") or "Array<" in rel_type
+
+            relationships.append(
+                {
+                    "name": name,
+                    "type": rel_type,
+                    "to_many": to_many,
+                }
+            )
+
+        return relationships
+
+
+# === OUTPUT FORMATTING ===
+
+
+def format_default(results: dict) -> str:
+    """Format results as token-efficient summary.
+
+    Args:
+        results: Parsed model data
+
+    Returns:
+        Formatted string (3-5 lines)
+    """
+    lines = []
+
+    for model in results["core_data"]:
+        entities = model["entities"]
+        attr_count = sum(len(e["attributes"]) for e in entities)
+        rel_count = sum(len(e["relationships"]) for e in entities)
+
+        version_info = f"{model['version_count']} version"
+        if model["version_count"] != 1:
+            version_info += "s"
+        if model["current_version"]:
+            current = model["current_version"].replace(".xcdatamodel", "")
+            version_info += f", current: {current}"
+
+        lines.append(f"Core Data: {model['package']} ({version_info})")
+        lines.append(
+            f"  {len(entities)} entities, {attr_count} attributes, {rel_count} relationships"
+        )
+
+    if results["swiftdata"]:
+        count = len(results["swiftdata"])
+        names = ", ".join(m["class_name"] for m in results["swiftdata"])
+        lines.append(f"SwiftData: {count} @Model class{'es' if count != 1 else ''} ({names})")
+
+    return "\n".join(lines)
+
+
+def format_verbose(results: dict) -> str:
+    """Format results with full details.
+
+    Args:
+        results: Parsed model data
+
+    Returns:
+        Formatted string with entity/attribute/relationship details
+    """
+    lines = []
+
+    for model in results["core_data"]:
+        lines.append(f"Core Data: {model['package']}")
+
+        if model.get("versions"):
+            version_list = []
+            for v in model["versions"]:
+                name = v["name"].replace(".xcdatamodel", "")
+                suffix = " (current)" if v["is_current"] else ""
+                version_list.append(f"{name}{suffix}")
+            lines.append(f"  Versions: {', '.join(version_list)}")
+
+        if model.get("current_version"):
+            current = model["current_version"].replace(".xcdatamodel", "")
+            lines.append(f"  Current version: {current}")
+
+        lines.append("")
+
+        for entity in model["entities"]:
+            attr_count = len(entity["attributes"])
+            rel_count = len(entity["relationships"])
+            abstract = " (abstract)" if entity.get("is_abstract") else ""
+            parent = f" extends {entity['parent_entity']}" if entity.get("parent_entity") else ""
+            lines.append(
+                f"  Entity: {entity['name']}{abstract}{parent}"
+                f" ({attr_count} attributes, {rel_count} relationships)"
+            )
+
+            if entity["attributes"]:
+                lines.append("    Attributes:")
+                for attr in entity["attributes"]:
+                    optional = "optional" if attr["optional"] else "required"
+                    default = f", default: {attr['default_value']}" if attr["default_value"] else ""
+                    lines.append(f"      - {attr['name']}: {attr['type']} ({optional}{default})")
+
+            if entity["relationships"]:
+                lines.append("    Relationships:")
+                for rel in entity["relationships"]:
+                    cardinality = "toMany" if rel["to_many"] else "toOne"
+                    inverse = f", inverse: {rel['inverse']}" if rel["inverse"] else ""
+                    lines.append(
+                        f"      - {rel['name']}: {rel['destination']} ({cardinality}{inverse})"
+                    )
+
+            if entity["fetch_requests"]:
+                lines.append("    Fetch Requests:")
+                for req in entity["fetch_requests"]:
+                    lines.append(f"      - {req['name']}: {req['predicate']}")
+
+            lines.append("")
+
+    if results["swiftdata"]:
+        lines.append("SwiftData:")
+        for model in results["swiftdata"]:
+            prop_count = len(model["properties"])
+            rel_count = len(model["relationships"])
+            lines.append(
+                f"  @Model {model['class_name']} ({prop_count} properties, {rel_count} relationships)"
+            )
+            lines.append(f"    File: {model['file']}")
+
+            if model["properties"]:
+                for prop in model["properties"]:
+                    lines.append(f"    - {prop['name']}: {prop['type']}")
+
+            if model["relationships"]:
+                for rel in model["relationships"]:
+                    cardinality = "toMany" if rel["to_many"] else "toOne"
+                    lines.append(f"    @Relationship {rel['name']}: {rel['type']} ({cardinality})")
+
+            lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Inspect Core Data and SwiftData models from project files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python scripts/model_inspector.py --project-path /path/to/project
+  python scripts/model_inspector.py --project-path . --verbose
+  python scripts/model_inspector.py --project-path . --json
+  python scripts/model_inspector.py --project-path . --show-versions
+  python scripts/model_inspector.py --project-path . --core-data-only
+        """,
+    )
+
+    inspection_group = parser.add_argument_group("Inspection Options")
+    inspection_group.add_argument(
+        "--project-path",
+        default=".",
+        help="Path to Xcode project root (default: current directory)",
+    )
+    inspection_group.add_argument(
+        "--core-data-only",
+        action="store_true",
+        help="Only inspect Core Data .xcdatamodeld packages",
+    )
+    inspection_group.add_argument(
+        "--swiftdata-only",
+        action="store_true",
+        help="Only inspect SwiftData @Model classes",
+    )
+    inspection_group.add_argument(
+        "--show-versions",
+        action="store_true",
+        help="List all model versions with current version highlighted",
+    )
+
+    output_group = parser.add_argument_group("Output Options")
+    output_group.add_argument("--json", action="store_true", help="Output as JSON")
+    output_group.add_argument("--verbose", action="store_true", help="Show full details")
+
+    args = parser.parse_args()
+
+    inspector = ModelInspector(project_path=args.project_path)
+    success, results = inspector.execute(
+        core_data_only=args.core_data_only,
+        swiftdata_only=args.swiftdata_only,
+        show_versions=args.show_versions,
+    )
+
+    if not success:
+        if "error" in results:
+            print(f"Error: {results['error']}", file=sys.stderr)
+        else:
+            print("No Core Data or SwiftData models found", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(results, indent=2, default=str))
+    elif args.verbose or args.show_versions:
+        print(format_verbose(results))
+    else:
+        print(format_default(results))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `model_inspector.py` — parses `.xcdatamodeld` packages and `@Model` Swift declarations from project source files
- Zero external dependencies (stdlib `xml.etree.ElementTree` + `plistlib` + regex)
- Follows existing script patterns: class-based, argparse groups, progressive disclosure output
- Updates SKILL.md, README.md, CLAUDE.md, plugin.json, marketplace.json (21 → 22 scripts)

Closes #33

## Test plan

- [x] Default output against real project (`~/Development/IOS/Zero`)
- [x] `--verbose --show-versions` output
- [x] `--json` structured output
- [x] `--core-data-only` / `--swiftdata-only` flags
- [x] No models found → exit 1 with message
- [x] `--help` output
- [x] ruff + black pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)