### PR TITLE
Add GitHub Pages landing site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#1f1f1f"/>
+  <circle cx="32" cy="32" r="10" fill="#f8f32b"/>
+  <circle cx="32" cy="32" r="14" fill="none" stroke="#f8f32b" stroke-opacity="0.28" stroke-width="3"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>iOS Simulator Skill — Build, test, and automate iOS apps with Claude Code</title>
+<meta name="description" content="Production-ready Claude Code skill for iOS development. 22 scripts for Xcode builds, semantic UI navigation, and accessibility testing — 96% token reduction vs raw tools.">
+<meta property="og:title" content="iOS Simulator Skill for Claude Code">
+<meta property="og:description" content="22 scripts for iOS app building, testing, and automation. Optimized for AI agents and developers.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://conorluddy.github.io/ios-simulator-skill/">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" href="favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Azeret+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<header class="nav">
+  <div class="container nav-inner">
+    <a class="brand" href="/ios-simulator-skill/">
+      <span class="brand-mark" aria-hidden="true"></span>
+      <span class="brand-name">ios-simulator <span>/ skill</span></span>
+    </a>
+    <nav class="nav-links">
+      <a href="#features">Features</a>
+      <a href="#scripts">Scripts</a>
+      <a href="#install">Install</a>
+      <a href="https://github.com/conorluddy/ios-simulator-skill" class="nav-github">GitHub →</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+
+<section class="hero">
+  <div class="container">
+    <div class="hero-meta">
+      <span class="tag">v1.0 · Plugin</span>
+      <span class="tag tag-muted">MIT · macOS 12+</span>
+    </div>
+    <h1>Build, test, and automate iOS apps&nbsp;with <em>Claude Code</em>.</h1>
+    <p class="lede">A production-ready skill of 22 scripts wrapping <code>xcodebuild</code>, <code>xcrun simctl</code>, and <code>idb</code> with semantic interfaces designed for AI agents and developers.</p>
+
+    <div class="cta-row">
+      <a class="btn btn-primary" href="#install">Install</a>
+      <a class="btn btn-ghost" href="https://github.com/conorluddy/ios-simulator-skill">View on GitHub</a>
+    </div>
+
+    <div class="stats">
+      <div class="stat">
+        <div class="stat-num">/01</div>
+        <div class="stat-value">22</div>
+        <div class="stat-label">Production scripts</div>
+      </div>
+      <div class="stat">
+        <div class="stat-num">/02</div>
+        <div class="stat-value">96<span style="color:var(--ink-dim);">%</span></div>
+        <div class="stat-label">Token reduction</div>
+      </div>
+      <div class="stat">
+        <div class="stat-num">/03</div>
+        <div class="stat-value">100<span style="color:var(--ink-dim);">%</span></div>
+        <div class="stat-label">Eval pass rate</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="features" class="section">
+  <div class="container">
+    <div class="section-head">
+      <span class="section-num">01 / WHY</span>
+      <h2 class="section-title">Why it matters.</h2>
+      <p class="section-sub">Three principles, applied to every script.</p>
+    </div>
+
+    <div class="features">
+      <article class="feature-card">
+        <span class="feature-num">A</span>
+        <h3>Token-efficient by default</h3>
+        <p>Default output is 3–5 lines. Drill into errors, warnings, or full logs only when you need them. Conversations stay focused, costs stay low.</p>
+      </article>
+      <article class="feature-card">
+        <span class="feature-num">B</span>
+        <h3>Semantic UI navigation</h3>
+        <p>Find elements by meaning — labels, types, IDs — not pixels. Built on the iOS accessibility tree, so tests survive UI redesigns.</p>
+      </article>
+      <article class="feature-card">
+        <span class="feature-num">C</span>
+        <h3>Production-ready</h3>
+        <p>Class-based scripts, type hints, Black + Ruff CI. Auto-UDID detection. Idempotent device lifecycle. Works with real simulators today.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-head">
+      <span class="section-num">02 / RECEIPTS</span>
+      <h2 class="section-title">Raw tools vs. this skill.</h2>
+      <p class="section-sub">A typical login flow with raw <code>idb</code> output is ~400 lines. With this skill, ~15.</p>
+    </div>
+
+    <div class="compare">
+      <div class="compare-card">
+        <p class="compare-task">Screen analysis</p>
+        <div class="compare-row"><span>Raw</span><span class="compare-bad">200+ lines</span></div>
+        <div class="compare-row"><span>Skill</span><span class="compare-good">5 lines</span></div>
+        <p class="compare-saving">−97.5%</p>
+      </div>
+      <div class="compare-card">
+        <p class="compare-task">Find &amp; tap button</p>
+        <div class="compare-row"><span>Raw</span><span class="compare-bad">100+ lines</span></div>
+        <div class="compare-row"><span>Skill</span><span class="compare-good">1 line</span></div>
+        <p class="compare-saving">−99%</p>
+      </div>
+      <div class="compare-card">
+        <p class="compare-task">Login flow</p>
+        <div class="compare-row"><span>Raw</span><span class="compare-bad">400+ lines</span></div>
+        <div class="compare-row"><span>Skill</span><span class="compare-good">15 lines</span></div>
+        <p class="compare-saving">−96%</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="install" class="section">
+  <div class="container">
+    <div class="section-head">
+      <span class="section-num">03 / INSTALL</span>
+      <h2 class="section-title">Install in Claude Code.</h2>
+      <p class="section-sub">Two commands, no setup. Restart Claude Code; the skill loads automatically.</p>
+    </div>
+
+    <div class="codeblock">
+      <div class="codeblock-head">
+        <span>~/claude-code</span>
+        <button class="copy-btn" type="button" aria-label="Copy install commands">Copy</button>
+      </div>
+<pre><code>/plugin marketplace add conorluddy/ios-simulator-skill
+/plugin install ios-simulator-skill@conorluddy</code></pre>
+    </div>
+    <p class="install-prereqs">Prerequisites: macOS 12+ · Xcode CLT · Python 3 · IDB (optional). <a href="https://github.com/conorluddy/ios-simulator-skill#prerequisites">Full list →</a></p>
+  </div>
+</section>
+
+<section id="scripts" class="section">
+  <div class="container">
+    <div class="section-head">
+      <span class="section-num">04 / CATALOG</span>
+      <h2 class="section-title">22 scripts. 5 categories.</h2>
+      <p class="section-sub">Every script supports <code>--help</code> and <code>--json</code>. Auto-detects the booted simulator unless you pass <code>--udid</code>.</p>
+    </div>
+
+    <div class="catalog">
+
+      <div class="catalog-group">
+        <div class="catalog-head">
+          <span class="catalog-num">/A</span>
+          <h3>Build &amp; Development</h3>
+        </div>
+        <ul>
+          <li><code>build_and_test.py</code><span>Build, test, parse xcresult bundles with progressive error disclosure</span></li>
+          <li><code>log_monitor.py</code><span>Real-time log monitoring with severity filtering</span></li>
+        </ul>
+      </div>
+
+      <div class="catalog-group">
+        <div class="catalog-head">
+          <span class="catalog-num">/B</span>
+          <h3>Navigation &amp; Interaction</h3>
+        </div>
+        <ul>
+          <li><code>screen_mapper.py</code><span>Analyze the current screen, list interactive elements</span></li>
+          <li><code>navigator.py</code><span>Find and interact with elements semantically</span></li>
+          <li><code>gesture.py</code><span>Swipes, scrolls, pinches, long press, pull to refresh</span></li>
+          <li><code>keyboard.py</code><span>Text input and hardware button control</span></li>
+          <li><code>app_launcher.py</code><span>Launch, terminate, install, deep link apps</span></li>
+        </ul>
+      </div>
+
+      <div class="catalog-group">
+        <div class="catalog-head">
+          <span class="catalog-num">/C</span>
+          <h3>Testing &amp; Analysis</h3>
+        </div>
+        <ul>
+          <li><code>accessibility_audit.py</code><span>WCAG compliance checking on the current screen</span></li>
+          <li><code>visual_diff.py</code><span>Compare two screenshots for visual changes</span></li>
+          <li><code>test_recorder.py</code><span>Automated test documentation with screenshots</span></li>
+          <li><code>app_state_capture.py</code><span>Debugging snapshots: screenshot, hierarchy, logs</span></li>
+          <li><code>sim_health_check.sh</code><span>Verify Xcode, simctl, IDB, Python toolchain</span></li>
+          <li><code>model_inspector.py</code><span>Inspect Core Data / SwiftData models from project files</span></li>
+        </ul>
+      </div>
+
+      <div class="catalog-group">
+        <div class="catalog-head">
+          <span class="catalog-num">/D</span>
+          <h3>Permissions &amp; Environment</h3>
+        </div>
+        <ul>
+          <li><code>clipboard.py</code><span>Copy text to simulator clipboard for paste testing</span></li>
+          <li><code>status_bar.py</code><span>Override status bar (time, battery, network)</span></li>
+          <li><code>push_notification.py</code><span>Send simulated push notifications</span></li>
+          <li><code>privacy_manager.py</code><span>Grant, revoke, reset app permissions across 13 services</span></li>
+        </ul>
+      </div>
+
+      <div class="catalog-group">
+        <div class="catalog-head">
+          <span class="catalog-num">/E</span>
+          <h3>Device Lifecycle</h3>
+        </div>
+        <ul>
+          <li><code>simctl_boot.py</code><span>Boot simulators with readiness verification</span></li>
+          <li><code>simctl_shutdown.py</code><span>Gracefully shutdown simulators</span></li>
+          <li><code>simctl_create.py</code><span>Create simulators by device type and OS version</span></li>
+          <li><code>simctl_delete.py</code><span>Delete simulators with safety confirmation</span></li>
+          <li><code>simctl_erase.py</code><span>Factory reset without deletion</span></li>
+        </ul>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-head">
+      <span class="section-num">05 / EVAL</span>
+      <h2 class="section-title">Measured against itself.</h2>
+      <p class="section-sub">Same iOS task suite. With and without the skill loaded. Run it yourself with <code>claude evals run</code>.</p>
+    </div>
+
+    <div class="eval">
+      <div class="eval-card">
+        <div class="eval-num">WITH SKILL</div>
+        <p class="eval-stat">100%</p>
+        <p class="eval-desc">3 of 3 tasks passed</p>
+      </div>
+      <div class="eval-card muted">
+        <div class="eval-num">WITHOUT SKILL</div>
+        <p class="eval-stat">46%</p>
+        <p class="eval-desc">~1.4 of 3 tasks passed</p>
+      </div>
+    </div>
+    <p class="eval-source">Tested with <a href="https://docs.claude.com/en/docs/claude-code/evals">Claude Code evals</a>.</p>
+  </div>
+</section>
+
+</main>
+
+<footer class="footer">
+  <div class="container footer-inner">
+    <p>MIT · Built by <a href="https://www.conor.fyi">Conor Luddy</a></p>
+    <nav class="footer-links">
+      <a href="https://github.com/conorluddy/ios-simulator-skill">GitHub</a>
+      <a href="https://deepwiki.com/conorluddy/ios-simulator-skill">DeepWiki</a>
+      <a href="https://www.conor.fyi/writing/ai-access">AI-accessible apps</a>
+    </nav>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('.copy-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const code = btn.closest('.codeblock').querySelector('code').innerText;
+      try {
+        await navigator.clipboard.writeText(code);
+        const original = btn.textContent;
+        btn.textContent = 'Copied';
+        btn.classList.add('is-copied');
+        setTimeout(() => { btn.textContent = original; btn.classList.remove('is-copied'); }, 1600);
+      } catch {}
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,642 @@
+:root {
+  --bg: #1f1f1f;
+  --panel: #2b2d42;
+  --panel-2: #252738;
+  --ink: #ffffff;
+  --ink-dim: #8d99ae;
+  --ink-faint: #5a6478;
+  --hair: #2b2d42;
+  --accent: #f8f32b;
+  --good: #f8f32b;
+  --warn: #f8f32b;
+  --bad: #8d99ae;
+  --info: #8d99ae;
+  --radius: 10px;
+  --container: 1200px;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'Azeret Mono', "SF Mono", ui-monospace, Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: var(--ink); text-decoration: none; transition: color 120ms; }
+a:hover { color: var(--accent); }
+
+code, pre, .mono {
+  font-family: var(--font-mono);
+  font-feature-settings: "ss01", "tnum";
+}
+
+code {
+  font-size: 0.9em;
+  color: var(--ink);
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  padding: 0.08em 0.4em;
+  border-radius: 4px;
+}
+
+.container {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+.eyebrow,
+.label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* === NAV === */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(31, 31, 31, 0.88);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--hair);
+}
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.brand:hover { color: var(--ink); }
+.brand-mark {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(248, 243, 43, 0.22);
+}
+.brand-name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.brand-name span { color: var(--ink-dim); }
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+.nav-links a {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.nav-links a:hover { color: var(--ink); }
+
+@media (max-width: 640px) {
+  .nav-links a:not(.nav-github) { display: none; }
+}
+
+/* === HERO === */
+.hero {
+  padding: 120px 0 96px;
+  border-bottom: 1px solid var(--hair);
+  position: relative;
+  overflow: hidden;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--hair) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hair) 1px, transparent 1px);
+  background-size: 80px 80px;
+  opacity: 0.25;
+  mask-image: radial-gradient(ellipse 60% 60% at 50% 40%, black 0%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse 60% 60% at 50% 40%, black 0%, transparent 80%);
+  pointer-events: none;
+}
+.hero .container { position: relative; }
+
+.hero-meta {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 32px;
+  align-items: center;
+}
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 4px 10px;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+}
+.tag-muted {
+  color: var(--ink-dim);
+  border-color: var(--hair);
+}
+
+.hero h1 {
+  font-size: clamp(40px, 6.5vw, 76px);
+  font-weight: 500;
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  margin: 0 0 24px;
+  max-width: 920px;
+}
+.hero h1 em {
+  font-style: normal;
+  color: var(--accent);
+}
+
+.lede {
+  font-size: clamp(15px, 1.5vw, 18px);
+  color: var(--ink-dim);
+  line-height: 1.5;
+  max-width: 640px;
+  margin: 0 0 40px;
+}
+.lede code {
+  background: transparent;
+  border: none;
+  color: var(--ink);
+  padding: 0;
+  font-size: 0.92em;
+}
+
+.cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 80px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 42px;
+  padding: 0 20px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 120ms;
+  border: 1px solid transparent;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #1f1f1f;
+}
+.btn-primary:hover { background: #fff95a; color: #1f1f1f; }
+.btn-ghost {
+  background: transparent;
+  color: var(--ink);
+  border-color: var(--hair);
+}
+.btn-ghost:hover { color: var(--ink); border-color: var(--ink-dim); }
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+}
+.stat {
+  padding: 28px 0 24px;
+  border-right: 1px solid var(--hair);
+}
+.stat:last-child { border-right: none; }
+.stat-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--ink-faint);
+  margin-bottom: 12px;
+}
+.stat-value {
+  font-size: clamp(40px, 5vw, 56px);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--ink);
+  margin-bottom: 10px;
+}
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+@media (max-width: 720px) {
+  .stats { grid-template-columns: 1fr; }
+  .stat { border-right: none; border-bottom: 1px solid var(--hair); }
+  .stat:last-child { border-bottom: none; }
+}
+
+/* === SECTIONS === */
+.section {
+  padding: 96px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.section-head {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 24px;
+  align-items: baseline;
+  margin-bottom: 56px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--hair);
+}
+.section-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--ink-faint);
+}
+.section-title {
+  font-size: clamp(28px, 3.5vw, 40px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  margin: 0;
+  line-height: 1.1;
+}
+.section-sub {
+  grid-column: 2;
+  margin: 12px 0 0;
+  color: var(--ink-dim);
+  font-size: 15px;
+  max-width: 720px;
+}
+.section-sub code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+}
+
+@media (max-width: 720px) {
+  .section-head { grid-template-columns: 1fr; gap: 8px; }
+  .section-sub { grid-column: 1; }
+}
+
+/* === FEATURES === */
+.features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.feature-card {
+  padding: 32px;
+  border-right: 1px solid var(--hair);
+  background: var(--panel);
+}
+.feature-card:last-child { border-right: none; }
+.feature-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  margin-bottom: 24px;
+  display: block;
+}
+.feature-card h3 {
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+  color: var(--ink);
+}
+.feature-card p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ink-dim);
+  line-height: 1.55;
+}
+@media (max-width: 820px) {
+  .features { grid-template-columns: 1fr; }
+  .feature-card { border-right: none; border-bottom: 1px solid var(--hair); }
+  .feature-card:last-child { border-bottom: none; }
+}
+
+/* === COMPARE === */
+.compare {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.compare-card {
+  padding: 28px;
+  background: var(--panel);
+  border-right: 1px solid var(--hair);
+}
+.compare-card:last-child { border-right: none; }
+.compare-task {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 20px;
+}
+.compare-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--hair);
+  font-size: 13px;
+}
+.compare-row:nth-of-type(2) { border-bottom: none; }
+.compare-row > span:first-child {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.compare-bad {
+  font-family: var(--font-mono);
+  color: var(--bad);
+  font-size: 13px;
+}
+.compare-good {
+  font-family: var(--font-mono);
+  color: var(--good);
+  font-size: 13px;
+}
+.compare-saving {
+  margin: 20px 0 0;
+  font-size: 28px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  font-family: var(--font-sans);
+}
+@media (max-width: 820px) {
+  .compare { grid-template-columns: 1fr; }
+  .compare-card { border-right: none; border-bottom: 1px solid var(--hair); }
+  .compare-card:last-child { border-bottom: none; }
+}
+
+/* === CODE BLOCK === */
+.codeblock {
+  position: relative;
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--panel);
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.codeblock-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--hair);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.codeblock pre {
+  margin: 0;
+  padding: 20px 24px;
+  font-size: 13px;
+  line-height: 1.7;
+  overflow-x: auto;
+  color: var(--ink);
+}
+.codeblock pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+.copy-btn {
+  background: transparent;
+  border: 1px solid var(--hair);
+  color: var(--ink-dim);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 120ms;
+}
+.copy-btn:hover {
+  color: var(--ink);
+  border-color: var(--ink-dim);
+}
+.copy-btn.is-copied {
+  color: #1f1f1f;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.install-prereqs {
+  text-align: center;
+  margin: 28px 0 0;
+  font-size: 13px;
+  color: var(--ink-dim);
+}
+
+/* === CATALOG === */
+.catalog {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.catalog-group {
+  padding: 28px 28px 12px;
+  background: var(--panel);
+  border-right: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+}
+.catalog-group:nth-child(2n) { border-right: none; }
+.catalog-group:nth-last-child(-n+1) { border-bottom: none; }
+.catalog-group:nth-last-child(2):nth-child(odd) { border-bottom: none; }
+
+.catalog-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--hair);
+}
+.catalog-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+}
+.catalog-group h3 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 0;
+}
+
+.catalog-group ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.catalog-group li {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--hair);
+}
+.catalog-group li:last-child { border-bottom: none; padding-bottom: 16px; }
+.catalog-group li code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.catalog-group li span {
+  font-size: 13px;
+  color: var(--ink-dim);
+  line-height: 1.5;
+}
+
+@media (max-width: 820px) {
+  .catalog { grid-template-columns: 1fr; }
+  .catalog-group { border-right: none; border-bottom: 1px solid var(--hair); }
+  .catalog-group:last-child { border-bottom: none; }
+}
+
+/* === QUOTE / EVAL === */
+.eval {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.eval-card {
+  padding: 48px 40px;
+  background: var(--panel);
+  border-right: 1px solid var(--hair);
+}
+.eval-card:last-child {
+  border-right: none;
+  background: var(--panel-2);
+}
+.eval-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--ink-faint);
+  margin-bottom: 16px;
+}
+.eval-stat {
+  font-size: clamp(48px, 7vw, 80px);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--accent);
+  margin: 0 0 16px;
+}
+.eval-card.muted .eval-stat { color: var(--ink-dim); }
+.eval-desc {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.eval-source {
+  margin-top: 32px;
+  font-size: 13px;
+  color: var(--ink-dim);
+  text-align: center;
+  padding: 0 24px;
+}
+@media (max-width: 720px) {
+  .eval { grid-template-columns: 1fr; }
+  .eval-card { border-right: none; border-bottom: 1px solid var(--hair); }
+  .eval-card:last-child { border-bottom: none; }
+}
+
+/* === FOOTER === */
+.footer {
+  padding: 40px 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.footer p { margin: 0; }
+.footer a { color: var(--ink-dim); }
+.footer a:hover { color: var(--accent); }
+.footer-links {
+  display: flex;
+  gap: 24px;
+}


### PR DESCRIPTION
## Summary

Adds a single-page landing site at `/site/` and a workflow that deploys it to GitHub Pages.

**Visual direction**: Teenage Engineering / Ocras-inspired — navy panels (`#2b2d42`), yellow accent (`#f8f32b`), Inter + Azeret Mono, numbered uppercase mono labels, hairline-divided panels (no card shadows).

## Changes

- `site/index.html` — single-page landing: nav, hero w/ stats grid, three-pane features, raw-vs-skill comparison cards, install snippet w/ copy button, 22-script catalog grouped by category, eval callout, footer.
- `site/styles.css` — design tokens, fully responsive, no JS framework.
- `site/favicon.svg` — yellow dot mark on dark.
- `.github/workflows/pages.yml` — deploys `/site/` on push to main using `configure-pages` / `upload-pages-artifact` / `deploy-pages`. Triggered by changes under `site/**` or the workflow itself, plus `workflow_dispatch`.

## One-time setup needed after merge

The first deploy will fail until Pages is switched to GitHub Actions:

> Repo → Settings → Pages → **Build and deployment → Source: GitHub Actions**

Then re-run the workflow (or push any tweak) and the site goes live at:
`https://conorluddy.github.io/ios-simulator-skill/`

## Test plan

- [x] Local preview via `python3 -m http.server` — checked desktop + mobile widths
- [ ] Merge → enable Pages source → confirm deploy succeeds
- [ ] Hit live URL, confirm hero/install/catalog all render and copy button works