### PR TITLE
fix: add skills field to plugin.json, bump to v1.4.1 (fixes #44)

### DIFF
--- a/ios-simulator-skill/.claude-plugin/plugin.json
+++ b/ios-simulator-skill/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-simulator-skill",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
   "author": {
     "name": "Conor Luddy"
@@ -8,5 +8,6 @@
   "license": "MIT",
   "homepage": "https://github.com/conorluddy/ios-simulator-skill",
   "repository": "https://github.com/conorluddy/ios-simulator-skill",
-  "keywords": ["ios", "simulator", "xcode", "testing", "accessibility", "automation"]
+  "keywords": ["ios", "simulator", "xcode", "testing", "accessibility", "automation"],
+  "skills": "skills"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ios-simulator-skill"
-version = "1.4.0"
+version = "1.4.1"
 description = "Build, test, and automate iOS apps with accessibility-driven navigation"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Problem

Claude Code's path validator rejects `"skills": ["./"]` with:
```
Path escapes plugin directory: ./ (skills)
```

The plugin directory structure was already correct (`skills/ios-simulator-skill/SKILL.md` in place), but `plugin.json` was missing the `skills` field entirely.

## Fix

Added `"skills": "skills"` to `plugin.json`, following the pattern used by other working plugins (e.g. Vercel's plugin).

Bumped version to `1.4.1` in both `plugin.json` and `pyproject.toml`.

## Result

Plugin loads correctly and skill is accessible as `ios-simulator-skill:ios-simulator-skill`.

Fixes #41
Fixes #44