### PR TITLE
fix: enforce Python 3.12+ in health check, bump to v1.4.2 (fixes #42)

### DIFF
--- a/ios-simulator-skill/.claude-plugin/plugin.json
+++ b/ios-simulator-skill/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-simulator-skill",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
   "author": {
     "name": "Conor Luddy"

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/sim_health_check.sh
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/sim_health_check.sh
@@ -133,15 +133,21 @@ else
 fi
 echo ""
 
-# Check 5: Python 3 installation
-echo -e "${BLUE}[5/8]${NC} Checking Python 3..."
+# Check 5: Python 3.12+ installation
+echo -e "${BLUE}[5/8]${NC} Checking Python 3.12+..."
 if command -v python3 &> /dev/null; then
-    PYTHON_VERSION=$(python3 --version | cut -d' ' -f2)
-    check_passed "Python 3 is installed (version $PYTHON_VERSION)"
+    PYTHON_MAJOR=$(python3 -c "import sys; print(sys.version_info.major)")
+    PYTHON_MINOR=$(python3 -c "import sys; print(sys.version_info.minor)")
+    if [ "$PYTHON_MAJOR" -lt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 12 ]; }; then
+        check_failed "Python $PYTHON_MAJOR.$PYTHON_MINOR found — Python 3.12+ required"
+        echo "       Upgrade: brew install python@3.12"
+    else
+        check_passed "Python $PYTHON_MAJOR.$PYTHON_MINOR (>= 3.12 required)"
+    fi
 else
     check_failed "Python 3 not found"
-    echo "       Python 3 is required for testing scripts"
-    echo "       Install: brew install python3"
+    echo "       Python 3.12+ is required for testing scripts"
+    echo "       Install: brew install python@3.12"
 fi
 echo ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ios-simulator-skill"
-version = "1.4.1"
+version = "1.4.2"
 description = "Build, test, and automate iOS apps with accessibility-driven navigation"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Problem

Issue #42 reported a cryptic `TypeError` on Python 3.9 from PEP 604 `Path | None` syntax. The minimum version (`>=3.12`) was already declared in `pyproject.toml` but invisible to users running scripts directly.

## Fix

`sim_health_check.sh` check 5 now verifies the installed Python is >= 3.12 and fails with a clear, actionable error if not:

```
✗ Python 3.9 found — Python 3.12+ required
  Upgrade: brew install python@3.12
```

## No code changes to scripts

The `pyproject.toml` declaration was always correct. This just surfaces the requirement before a confusing runtime error occurs.

Fixes #42