### PR TITLE
fix: remove invalid 'skills' field from plugin.json (#50)

### DIFF
--- a/ios-simulator-skill/.claude-plugin/plugin.json
+++ b/ios-simulator-skill/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   "license": "MIT",
   "homepage": "https://github.com/conorluddy/ios-simulator-skill",
   "repository": "https://github.com/conorluddy/ios-simulator-skill",
-  "keywords": ["ios", "simulator", "xcode", "testing", "accessibility", "automation"],
-  "skills": "skills"
+  "keywords": ["ios", "simulator", "xcode", "testing", "accessibility", "automation"]
 }


### PR DESCRIPTION
Fixes #50.

Claude Code's plugin schema rejects `"skills": "skills"` (string value). Since the layout already places the skill at `skills/ios-simulator-skill/SKILL.md`, removing the field allows auto-discovery.

## Repro before fix
```
/plugin install ios-simulator-skill@conorluddy
Error: skills: Invalid input
```

## Change
- Drop the `"skills": "skills"` line from `ios-simulator-skill/.claude-plugin/plugin.json`.