### PR TITLE
chore: update dev tooling and fix stale lint path globs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install linting tools
         run: |
           python -m pip install --upgrade pip
-          pip install black ruff
+          pip install 'black==26.5.1' 'ruff==0.15.14'
 
       - name: Run Black (formatter check)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,21 +5,21 @@
 repos:
   # Black - Code formatter
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.5.1
     hooks:
       - id: black
         name: Format Python code with Black
         language_version: python3.12
-        files: ^skill/scripts/.*\.py$
+        files: ^ios-simulator-skill/skills/ios-simulator-skill/scripts/.*\.py$
 
   # Ruff - Fast linter (replaces Flake8, isort, etc)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.15.14
     hooks:
       - id: ruff
         name: Lint with Ruff
         args: [--fix, --exit-non-zero-on-fix]
-        files: ^skill/scripts/.*\.py$
+        files: ^ios-simulator-skill/skills/ios-simulator-skill/scripts/.*\.py$
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ extend-exclude = '''
 line-length = 100
 target-version = "py312"
 # Only check skill code, not root-level dev scripts
-include = ["ios-simulator-skill/scripts/**/*.py"]
+include = ["ios-simulator-skill/skills/ios-simulator-skill/scripts/**/*.py"]
 
 [tool.ruff.lint]
 # Enable ALL recommended rules (strict mode)


### PR DESCRIPTION
## Summary

Dependency audit follow-up. No runtime deps (stdlib only) — all changes are dev tooling.

## Changes

- **Black**: `24.10.0` → `26.5.1`
- **Ruff**: `0.7.4` → `0.15.14`
- **CI lint workflow**: pin Black/Ruff to match pre-commit (was unpinned, causing drift between local and CI)
- **pre-commit globs**: fixed stale `^skill/scripts/` path — previously matched **zero files**, so the hooks were a no-op
- **`pyproject.toml` ruff include**: same stale path fixed

## Verification

- `black --check --diff` → 34 files unchanged
- `ruff check` → all checks passed (now actually checking files)