### PR TITLE
feat: configurable limits and bumped defaults (v1.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,20 +141,105 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 
 ## Configuration
 
-Operational limits (timeouts, output caps, polling intervals, cache size) are tunable via `IOS_SIM_*` environment variables. The full reference table — every variable, default, and purpose — lives in [SKILL.md → Configuration](ios-simulator-skill/skills/ios-simulator-skill/SKILL.md#configuration).
+Every operational limit — timeouts, output caps, polling intervals, cache size, post-action delays — is tunable via an `IOS_SIM_*` environment variable. Defaults are tuned for **local development on Apple Silicon**. Raise them on slow CI runners, large monorepos, or accessibility audits over complex screens. Lower them when you need faster failure or tighter token budgets.
 
-Common examples:
+There's a universal tradeoff to keep in mind:
+
+- **Higher caps / longer timeouts** → fewer false failures, more complete diagnostics, **more tokens** consumed by AI agents and slower failures when something is genuinely broken.
+- **Lower caps / shorter timeouts** → faster feedback, tighter token usage, **risk** of silently dropped errors or premature timeouts on legitimately slow operations.
+
+### Boot & lifecycle timeouts
+
+How long to wait on `xcrun simctl` operations.
+
+| Variable | Default | Tradeoff |
+|---|---|---|
+| `IOS_SIM_BOOT_TIMEOUT` | `300` (s) | Wait for simulator readiness after `boot`. Lower → faster failure on broken sims. Higher → survives cold-start on slow CI runners (GitHub-hosted macOS can need 4–6 min). |
+| `IOS_SIM_BOOT_SUBPROCESS_TIMEOUT` | `60` (s) | Timeout for the `simctl boot` call itself (before readiness polling starts). Rarely needs changing; bump only if you see `Boot command timed out` on resource-starved CI. |
+| `IOS_SIM_ERASE_TIMEOUT` | `90` (s) | Wait for factory-reset verification. Larger simulators (lots of installed apps + data) can need more than the old 30s. |
+| `IOS_SIM_POLL_INTERVAL` | `0.5` (s) | How often to re-check boot/erase state. Lower → more responsive (more CPU). Higher → quieter on slow CI but adds latency to “ready” detection. |
+| `IOS_SIM_STATE_SUBPROCESS_TIMEOUT` | `15` (s) | Per-subprocess timeout in `app_state_capture.py`. Bump for apps with very large accessibility trees. |
+
+### Build & test output caps
+
+`build_and_test.py` returns counts by default and full details via xcresult ID; these caps govern what's surfaced in human/JSON output **before** progressive disclosure kicks in.
+
+| Variable | Default | Tradeoff |
+|---|---|---|
+| `IOS_SIM_BUILD_SUMMARY_CAP` | `15` | Errors / failed tests in the default text summary. Lower → terser default output. Higher → less need to chase xcresult IDs for context. |
+| `IOS_SIM_BUILD_VERBOSE_CAP` | `100` | Errors / warnings in `--verbose` mode. Mostly relevant for monorepos or first builds with many fixable warnings. |
+| `IOS_SIM_BUILD_JSON_CAP` | `50` | Max errors / failed tests in `--json` output. Raise for CI dashboards that need exhaustive lists. |
+| `IOS_SIM_BUILD_LOG_PREVIEW` | `4000` (chars) | Chars of build log included in default output. Higher → more context for failures, more tokens. |
+
+### Log monitor output
+
+`log_monitor.py` aggregates `os_log` output; these caps shape both the text summary and the structured JSON.
+
+| Variable | Default | Tradeoff |
+|---|---|---|
+| `IOS_SIM_LOG_TEXT_SUMMARY` | `15` | Errors / warnings shown in the text summary. The default surfaces enough for most debugging without flooding terminal output. |
+| `IOS_SIM_LOG_LINE_MAX` | `300` (chars) | Per-line truncation. Crash messages with full Swift symbol mangling can exceed 200 chars; raise if you see “…” cutting off the actionable bit. |
+| `IOS_SIM_LOG_TAIL` | `200` (lines) | Recent log lines shown in verbose mode and JSON `sample_logs`. Also used by xcode log excerpt. Lower for tighter context, higher for richer post-mortems. |
+| `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors / warnings in JSON output. Raise if you're piping into a dashboard that needs the full picture. |
+
+### UI navigation & screen mapping
+
+These shape what AI agents see when exploring a screen. They're the biggest direct lever on token consumption per navigation step.
+
+| Variable | Default | Tradeoff |
+|---|---|---|
+| `IOS_SIM_MAX_ELEMENTS` | `25` | Tappable elements listed by `navigator.py`. Default is enough for most screens; raise to `100+` for dense Settings-style screens or audit workflows. **High token impact** at high values. |
+| `IOS_SIM_SCREEN_BUTTONS_PREVIEW` | `15` | Button names in `screen_mapper.py` summary. |
+| `IOS_SIM_SCREEN_SECTION_ITEMS` | `10` | Items per section in `screen_mapper.py` summary. |
+| `IOS_SIM_APPS_PREVIEW` | `30` | Installed apps listed by `app_launcher.py` before truncation. |
+| `IOS_SIM_TAP_SETTLE_MS` | `500` (ms) | Delay after a tap before reading new state. Lower → faster navigation on snappy apps. Higher → safer on apps with heavy animations or async loading; raises end-to-end test runtime linearly. |
+| `IOS_SIM_RELAUNCH_DELAY_MS` | `1000` (ms) | Delay between terminate and re-launch in `app_launcher.py --restart`. Raise if you see relaunches catching the previous process still tearing down. |
+
+### Accessibility audit
+
+| Variable | Default | Tradeoff |
+|---|---|---|
+| `IOS_SIM_A11Y_TOP_ISSUES` | `10` | Top issues surfaced per audit. Default of 3 in older versions was almost always too aggressive for real-world apps. Raise for first-pass audits, lower for regression checks. |
+| `IOS_SIM_A11Y_LABEL_MAX` | `80` (chars) | Max chars of `AXLabel` retained in audit output. Custom localized labels often exceed 30 chars; 80 catches almost all. |
+
+### Progressive disclosure cache
+
+`ProgressiveCache` stores large outputs (build results, log dumps) keyed by short IDs so the default output stays minimal.
+
+| Variable | Default | Tradeoff |
+|---|---|---|
+| `IOS_SIM_CACHE_TTL_HOURS` | `1` | How long cache entries remain valid. Lower → fresher data on next retrieve, more re-runs. Higher → faster reruns in long CI pipelines, risk of stale results if simulator state changed. |
+| `IOS_SIM_CACHE_MAX_ENTRIES` | `500` | Hard cap; oldest entries (by mtime) are evicted on every `save()`. Prevents unbounded growth of `~/.ios-simulator-skill/cache/` in long-running environments. Raise only if you frequently need to retrieve entries older than ~500 saves. |
+
+### Examples
 
 ```bash
-# Slow CI runner — give boot up to 10 minutes
+# Slow GitHub Actions macOS runner — give boot up to 10 minutes
 IOS_SIM_BOOT_TIMEOUT=600 python scripts/simctl_boot.py --wait-ready
 
-# Large monorepo build — surface up to 200 errors instead of the default 100
-IOS_SIM_BUILD_VERBOSE_CAP=200 python scripts/build_and_test.py --verbose
+# Monorepo with hundreds of warnings — see them all in verbose mode
+IOS_SIM_BUILD_VERBOSE_CAP=500 python scripts/build_and_test.py --verbose
 
-# Audit a complex screen — return more tappable elements
+# Complex Settings-style screen — return more tappable elements
 IOS_SIM_MAX_ELEMENTS=100 python scripts/navigator.py --list-tappable
+
+# Snappy app — cut tap-settle delay in half for faster E2E runs
+IOS_SIM_TAP_SETTLE_MS=250 python scripts/navigator.py --find-text "Login" --tap
+
+# Long CI pipeline — keep cache entries valid for the whole job
+IOS_SIM_CACHE_TTL_HOURS=8 python scripts/build_and_test.py --project MyApp.xcodeproj
 ```
+
+You can also export the vars once for the whole session:
+
+```bash
+export IOS_SIM_BOOT_TIMEOUT=600
+export IOS_SIM_LOG_TAIL=500
+export IOS_SIM_MAX_ELEMENTS=50
+# … all subsequent scripts honor them
+```
+
+Parse errors fall back to the documented default with a warning on stderr — no scripts will crash on a malformed env var.
 
 ## Evaluation
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ How long to wait on `xcrun simctl` operations.
 | `IOS_SIM_BUILD_VERBOSE_CAP` | `100` | Errors / warnings in `--verbose` mode. Mostly relevant for monorepos or first builds with many fixable warnings. |
 | `IOS_SIM_BUILD_JSON_CAP` | `50` | Max errors / failed tests in `--json` output. Raise for CI dashboards that need exhaustive lists. |
 | `IOS_SIM_BUILD_LOG_PREVIEW` | `4000` (chars) | Chars of build log included in default output. Higher → more context for failures, more tokens. |
+| `IOS_SIM_BUILD_TIMEOUT` | `1800` (s) | Hard cap on a single `xcodebuild build` invocation. Default of 30 min covers most clean builds of large apps; raise for very large monorepos, lower to fail fast in CI when builds are expected to take seconds. Without this, a hung `xcodebuild` would block forever. |
+| `IOS_SIM_TEST_TIMEOUT` | `2700` (s) | Hard cap on `xcodebuild test`. Tests can take significantly longer than builds (45 min default) because of simulator boot + animation delays. |
+| `IOS_SIM_INTROSPECT_TIMEOUT` | `60` (s) | Timeout for `xcodebuild -list` and `xcrun simctl list` introspection calls. These should normally complete in &lt;1s; 60s catches Xcode-toolchain hangs without disrupting cold-start. |
 
 ### Log monitor output
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 | `simctl_delete.py` | Delete simulators with safety confirmation | `--name`, `--yes`, `--all`, `--old` |
 | `simctl_erase.py` | Factory reset without deletion | `--name`, `--verify`, `--all`, `--booted` |
 
+## Configuration
+
+Operational limits (timeouts, output caps, polling intervals, cache size) are tunable via `IOS_SIM_*` environment variables. The full reference table — every variable, default, and purpose — lives in [SKILL.md → Configuration](ios-simulator-skill/skills/ios-simulator-skill/SKILL.md#configuration).
+
+Common examples:
+
+```bash
+# Slow CI runner — give boot up to 10 minutes
+IOS_SIM_BOOT_TIMEOUT=600 python scripts/simctl_boot.py --wait-ready
+
+# Large monorepo build — surface up to 200 errors instead of the default 100
+IOS_SIM_BUILD_VERBOSE_CAP=200 python scripts/build_and_test.py --verbose
+
+# Audit a complex screen — return more tappable elements
+IOS_SIM_MAX_ELEMENTS=100 python scripts/navigator.py --list-tappable
+```
+
 ## Evaluation
 
 Tested using [Claude Code evals](https://docs.claude.com/en/docs/claude-code/evals):

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -226,6 +226,9 @@ Most operational limits can be tuned via environment variables. Defaults work fo
 | `IOS_SIM_BOOT_TIMEOUT` | `300` | Wait-for-ready timeout after boot (seconds) |
 | `IOS_SIM_BUILD_JSON_CAP` | `50` | Max build errors / failed tests in JSON output |
 | `IOS_SIM_BUILD_LOG_PREVIEW` | `4000` | Chars of build log preview in default output |
+| `IOS_SIM_BUILD_TIMEOUT` | `1800` | Max seconds for an `xcodebuild build` invocation before kill |
+| `IOS_SIM_INTROSPECT_TIMEOUT` | `60` | Timeout for `xcodebuild -list` and `simctl list` lookups (seconds) |
+| `IOS_SIM_TEST_TIMEOUT` | `2700` | Max seconds for an `xcodebuild test` invocation before kill |
 | `IOS_SIM_BUILD_SUMMARY_CAP` | `15` | Errors/failures in default build summary |
 | `IOS_SIM_BUILD_VERBOSE_CAP` | `100` | Errors/warnings in verbose build output |
 | `IOS_SIM_CACHE_MAX_ENTRIES` | `500` | Max entries in progressive disclosure cache (LRU eviction) |

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ios-simulator-skill
-version: 1.4.0
+version: 1.5.0
 description: 22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
 ---
 
@@ -212,6 +212,43 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
 4. Interact: `python scripts/navigator.py --find-text "Button" --tap`
 5. Verify: `python scripts/accessibility_audit.py`
 6. Debug if needed: `python scripts/app_state_capture.py --app-bundle-id com.example.app`
+
+## Configuration
+
+Most operational limits can be tuned via environment variables. Defaults work for typical local development; raise them for slow CI runners, large monorepo builds, or accessibility audits on complex screens.
+
+| Variable | Default | Controls |
+|---|---|---|
+| `IOS_SIM_A11Y_LABEL_MAX` | `80` | Max chars of `AXLabel` retained in accessibility audit output |
+| `IOS_SIM_A11Y_TOP_ISSUES` | `10` | Top accessibility issues surfaced per audit |
+| `IOS_SIM_APPS_PREVIEW` | `30` | App entries listed by `app_launcher.py` before truncation |
+| `IOS_SIM_BOOT_SUBPROCESS_TIMEOUT` | `60` | Timeout for the `simctl boot` subprocess itself (seconds) |
+| `IOS_SIM_BOOT_TIMEOUT` | `300` | Wait-for-ready timeout after boot (seconds) |
+| `IOS_SIM_BUILD_JSON_CAP` | `50` | Max build errors / failed tests in JSON output |
+| `IOS_SIM_BUILD_LOG_PREVIEW` | `4000` | Chars of build log preview in default output |
+| `IOS_SIM_BUILD_SUMMARY_CAP` | `15` | Errors/failures in default build summary |
+| `IOS_SIM_BUILD_VERBOSE_CAP` | `100` | Errors/warnings in verbose build output |
+| `IOS_SIM_CACHE_MAX_ENTRIES` | `500` | Max entries in progressive disclosure cache (LRU eviction) |
+| `IOS_SIM_CACHE_TTL_HOURS` | `1` | Cache entry expiration |
+| `IOS_SIM_ERASE_TIMEOUT` | `90` | Wait-for-erase timeout (seconds) |
+| `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors/warnings in `log_monitor.py` JSON output |
+| `IOS_SIM_LOG_LINE_MAX` | `300` | Per-line truncation in log summaries |
+| `IOS_SIM_LOG_TAIL` | `200` | Lines of log tail in verbose / sample output |
+| `IOS_SIM_LOG_TEXT_SUMMARY` | `15` | Errors/warnings shown in text-mode log summary |
+| `IOS_SIM_MAX_ELEMENTS` | `25` | Tappable elements listed by `navigator.py` |
+| `IOS_SIM_POLL_INTERVAL` | `0.5` | Boot/erase state polling interval (seconds) |
+| `IOS_SIM_RELAUNCH_DELAY_MS` | `1000` | Delay between terminate and re-launch in `app_launcher.py` |
+| `IOS_SIM_SCREEN_BUTTONS_PREVIEW` | `15` | Button names listed by `screen_mapper.py` |
+| `IOS_SIM_SCREEN_SECTION_ITEMS` | `10` | Items per section shown by `screen_mapper.py` |
+| `IOS_SIM_STATE_SUBPROCESS_TIMEOUT` | `15` | Subprocess timeout in `app_state_capture.py` (seconds) |
+| `IOS_SIM_TAP_SETTLE_MS` | `500` | Post-tap settle delay in `navigator.py` |
+
+Example:
+
+```bash
+# Slow GitHub Actions runner: give boot 10 minutes
+IOS_SIM_BOOT_TIMEOUT=600 python scripts/simctl_boot.py --wait-ready
+```
 
 ## Requirements
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/accessibility_audit.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/accessibility_audit.py
@@ -16,6 +16,10 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from common import flatten_tree, get_accessibility_tree, resolve_udid
+from common.env_config import env_int
+
+A11Y_LABEL_MAX = env_int("IOS_SIM_A11Y_LABEL_MAX", 80)
+A11Y_TOP_ISSUES = env_int("IOS_SIM_A11Y_TOP_ISSUES", 10)
 
 
 @dataclass
@@ -168,7 +172,11 @@ class AccessibilityAuditor:
                 # Add minimal element info for context
                 issue_dict["element"] = {
                     "type": element.get("type", "Unknown"),
-                    "label": element.get("AXLabel", "")[:30] if element.get("AXLabel") else None,
+                    "label": (
+                        element.get("AXLabel", "")[:A11Y_LABEL_MAX]
+                        if element.get("AXLabel")
+                        else None
+                    ),
                 }
                 all_issues.append(issue_dict)
 
@@ -221,7 +229,7 @@ class AccessibilityAuditor:
             grouped.values(), key=lambda x: (severity_order[x["severity"]], -x["count"])
         )
 
-        return sorted_issues[:3]
+        return sorted_issues[:A11Y_TOP_ISSUES]
 
 
 def main():

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/app_launcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/app_launcher.py
@@ -308,8 +308,8 @@ def main():
             print(f"Installed apps ({len(apps)}):")
             for app in apps[:APPS_PREVIEW]:
                 print(f"  {app['bundle_id']}: {app['name']} (v{app['version']})")
-            if len(apps) > 10:
-                print(f"  ... and {len(apps) - 10} more")
+            if len(apps) > APPS_PREVIEW:
+                print(f"  ... and {len(apps) - APPS_PREVIEW} more")
         else:
             print("No apps found or failed to list")
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/app_launcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/app_launcher.py
@@ -15,6 +15,10 @@ import sys
 import time
 
 from common import build_simctl_command, resolve_udid
+from common.env_config import env_float, env_int
+
+RELAUNCH_DELAY_SECONDS = env_float("IOS_SIM_RELAUNCH_DELAY_MS", 1000.0) / 1000.0
+APPS_PREVIEW = env_int("IOS_SIM_APPS_PREVIEW", 30)
 
 
 class AppLauncher:
@@ -197,7 +201,7 @@ class AppLauncher:
         except subprocess.CalledProcessError:
             return "unknown"
 
-    def restart_app(self, bundle_id: str, delay: float = 1.0) -> bool:
+    def restart_app(self, bundle_id: str, delay: float = RELAUNCH_DELAY_SECONDS) -> bool:
         """
         Restart an app (terminate then launch).
 
@@ -302,7 +306,7 @@ def main():
         apps = launcher.list_apps()
         if apps:
             print(f"Installed apps ({len(apps)}):")
-            for app in apps[:10]:  # Limit for token efficiency
+            for app in apps[:APPS_PREVIEW]:
                 print(f"  {app['bundle_id']}: {app['name']} (v{app['version']})")
             if len(apps) > 10:
                 print(f"  ... and {len(apps) - 10} more")

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/app_state_capture.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/app_state_capture.py
@@ -21,6 +21,9 @@ from common import (
     get_accessibility_tree,
     resolve_udid,
 )
+from common.env_config import env_int
+
+STATE_SUBPROCESS_TIMEOUT = env_int("IOS_SIM_STATE_SUBPROCESS_TIMEOUT", 15)
 
 
 class AppStateCapture:
@@ -109,7 +112,13 @@ class AppStateCapture:
         )
 
         try:
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=5)
+            result = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=STATE_SUBPROCESS_TIMEOUT,
+            )
             logs = result.stdout
 
             # Limit lines for token efficiency

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/build_and_test.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/build_and_test.py
@@ -39,7 +39,12 @@ import sys
 from pathlib import Path
 
 # Import our modular components
+from common.env_config import env_int
+
 from xcode import BuildRunner, OutputFormatter, XCResultCache, XCResultParser
+
+BUILD_LOG_PREVIEW_CHARS = env_int("IOS_SIM_BUILD_LOG_PREVIEW", 4000)
+BUILD_JSON_CAP = env_int("IOS_SIM_BUILD_JSON_CAP", 50)
 
 
 def main():
@@ -193,7 +198,7 @@ Examples:
                     "warning_count": warning_count,
                     "errors": errors,
                     "warnings": warnings,
-                    "log_preview": build_log[:1000] if build_log else None,
+                    "log_preview": build_log[:BUILD_LOG_PREVIEW_CHARS] if build_log else None,
                 }
                 print(json.dumps(data, indent=2))
             else:
@@ -303,9 +308,9 @@ Examples:
             data["test_info"] = test_info
         if not success:
             if errors:
-                data["errors"] = errors[:10]
+                data["errors"] = errors[:BUILD_JSON_CAP]
             if failed_tests:
-                data["failed_tests"] = failed_tests[:10]
+                data["failed_tests"] = failed_tests[:BUILD_JSON_CAP]
         if hints:
             data["hints"] = hints
         import json

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/cache_utils.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/cache_utils.py
@@ -15,11 +15,17 @@ Used by:
 - Future: build logs, UI trees, etc.
 """
 
+import contextlib
 import json
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+from common.env_config import env_int
+
+DEFAULT_MAX_AGE_HOURS = env_int("IOS_SIM_CACHE_TTL_HOURS", 1)
+DEFAULT_MAX_ENTRIES = env_int("IOS_SIM_CACHE_MAX_ENTRIES", 500)
 
 
 class ProgressiveCache:
@@ -29,21 +35,43 @@ class ProgressiveCache:
     Automatically cleans up expired entries.
     """
 
-    def __init__(self, cache_dir: str | None = None, max_age_hours: int = 1):
+    def __init__(
+        self,
+        cache_dir: str | None = None,
+        max_age_hours: int | None = None,
+        max_entries: int | None = None,
+    ):
         """Initialize cache system.
 
         Args:
             cache_dir: Cache directory path (default: ~/.ios-simulator-skill/cache/)
-            max_age_hours: Max age for cache entries before expiration (default: 1 hour)
+            max_age_hours: Max age for cache entries before expiration. Defaults to
+                ``IOS_SIM_CACHE_TTL_HOURS`` env var, or 1 hour.
+            max_entries: Maximum entries retained; oldest are evicted (LRU by mtime).
+                Defaults to ``IOS_SIM_CACHE_MAX_ENTRIES`` env var, or 500.
         """
         if cache_dir is None:
             cache_dir = str(Path("~/.ios-simulator-skill/cache").expanduser())
 
         self.cache_dir = Path(cache_dir)
-        self.max_age_hours = max_age_hours
+        self.max_age_hours = max_age_hours if max_age_hours is not None else DEFAULT_MAX_AGE_HOURS
+        self.max_entries = max_entries if max_entries is not None else DEFAULT_MAX_ENTRIES
 
         # Create cache directory if needed
         self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _evict_overflow(self) -> int:
+        """Evict oldest entries when count exceeds ``max_entries``. Returns count evicted."""
+        files = list(self.cache_dir.glob("*.json"))
+        if len(files) <= self.max_entries:
+            return 0
+        # Sort oldest-first by mtime; delete the head of the overflow
+        files.sort(key=lambda p: p.stat().st_mtime)
+        to_remove = len(files) - self.max_entries
+        for path in files[:to_remove]:
+            with contextlib.suppress(OSError):
+                path.unlink()
+        return to_remove
 
     def save(self, data: dict[str, Any], cache_type: str) -> str:
         """Save data to cache and return cache_id.
@@ -78,6 +106,7 @@ class ProgressiveCache:
                 indent=2,
             )
 
+        self._evict_overflow()
         return cache_id
 
     def get(self, cache_id: str) -> dict[str, Any] | None:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/env_config.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/env_config.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Env-var overrides for tunable defaults.
+
+All overrides use the ``IOS_SIM_`` prefix. See SKILL.md → Configuration
+for the canonical list of supported variables.
+"""
+
+import os
+import sys
+
+
+def env_int(name: str, default: int, min_value: int = 1) -> int:
+    """Read ``name`` as an int, falling back to ``default`` on miss or parse error."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"warning: {name}={raw!r} is not an int; using default {default}", file=sys.stderr)
+        return default
+    return max(value, min_value)
+
+
+def env_float(name: str, default: float, min_value: float = 0.0) -> float:
+    """Read ``name`` as a float, falling back to ``default`` on miss or parse error."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        print(f"warning: {name}={raw!r} is not a float; using default {default}", file=sys.stderr)
+        return default
+    return max(value, min_value)

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/log_monitor.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/log_monitor.py
@@ -39,6 +39,13 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from common.env_config import env_int
+
+LOG_LINE_MAX = env_int("IOS_SIM_LOG_LINE_MAX", 300)
+LOG_TAIL = env_int("IOS_SIM_LOG_TAIL", 200)
+LOG_TEXT_SUMMARY_CAP = env_int("IOS_SIM_LOG_TEXT_SUMMARY", 15)
+LOG_JSON_CAP = env_int("IOS_SIM_LOG_JSON_CAP", 100)
+
 
 class LogMonitor:
     """Monitor and analyze iOS simulator logs with intelligent filtering."""
@@ -324,18 +331,18 @@ class LogMonitor:
         # Top issues
         if self.errors:
             lines.append(f"\nTop Errors ({len(self.errors)}):")
-            for error in self.errors[:5]:  # Show first 5
-                lines.append(f"  ❌ {error[:120]}")  # Truncate long lines
+            for error in self.errors[:LOG_TEXT_SUMMARY_CAP]:
+                lines.append(f"  ❌ {error[:LOG_LINE_MAX]}")
 
         if self.warnings:
             lines.append(f"\nTop Warnings ({len(self.warnings)}):")
-            for warning in self.warnings[:5]:  # Show first 5
-                lines.append(f"  ⚠️  {warning[:120]}")
+            for warning in self.warnings[:LOG_TEXT_SUMMARY_CAP]:
+                lines.append(f"  ⚠️  {warning[:LOG_LINE_MAX]}")
 
         # Verbose output
         if verbose and self.log_lines:
             lines.append("\n=== Recent Log Lines ===")
-            for line in self.log_lines[-50:]:  # Last 50 lines
+            for line in self.log_lines[-LOG_TAIL:]:
                 lines.append(line)
 
         return "\n".join(lines)
@@ -352,9 +359,9 @@ class LogMonitor:
                 "info": self.info_count,
                 "debug": self.debug_count,
             },
-            "errors": self.errors[:20],  # Limit to 20
-            "warnings": self.warnings[:20],
-            "sample_logs": self.log_lines[-50:],  # Last 50 lines
+            "errors": self.errors[:LOG_JSON_CAP],
+            "warnings": self.warnings[:LOG_JSON_CAP],
+            "sample_logs": self.log_lines[-LOG_TAIL:],
         }
 
     def save_logs(self, output_dir: str) -> str:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/navigator.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/navigator.py
@@ -67,6 +67,10 @@ from common import (
     resolve_udid,
     transform_screenshot_coords,
 )
+from common.env_config import env_float, env_int
+
+MAX_ELEMENTS_LISTED = env_int("IOS_SIM_MAX_ELEMENTS", 25)
+TAP_SETTLE_SECONDS = env_float("IOS_SIM_TAP_SETTLE_MS", 500.0) / 1000.0
 
 
 @dataclass
@@ -231,7 +235,7 @@ class Navigator:
             # Small delay for focus
             import time
 
-            time.sleep(0.5)
+            time.sleep(TAP_SETTLE_SECONDS)
 
         # Enter text
         cmd = ["idb", "ui", "text", text]
@@ -360,7 +364,7 @@ def main():
         ]
 
         print(f"Tappable elements ({len(tappable)}):")
-        for elem in tappable[:10]:  # Limit output for tokens
+        for elem in tappable[:MAX_ELEMENTS_LISTED]:
             print(f"  {elem.type}: \"{elem.label or elem.value or 'Unnamed'}\" {elem.center}")
 
         if len(tappable) > 10:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/navigator.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/navigator.py
@@ -367,8 +367,8 @@ def main():
         for elem in tappable[:MAX_ELEMENTS_LISTED]:
             print(f"  {elem.type}: \"{elem.label or elem.value or 'Unnamed'}\" {elem.center}")
 
-        if len(tappable) > 10:
-            print(f"  ... and {len(tappable) - 10} more")
+        if len(tappable) > MAX_ELEMENTS_LISTED:
+            print(f"  ... and {len(tappable) - MAX_ELEMENTS_LISTED} more")
         sys.exit(0)
 
     # Direct tap at coordinates

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/screen_mapper.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/screen_mapper.py
@@ -50,6 +50,10 @@ import sys
 from collections import defaultdict
 
 from common import get_accessibility_tree, resolve_udid
+from common.env_config import env_int
+
+BUTTONS_PREVIEW = env_int("IOS_SIM_SCREEN_BUTTONS_PREVIEW", 15)
+SECTION_ITEMS_PREVIEW = env_int("IOS_SIM_SCREEN_SECTION_ITEMS", 10)
 
 
 class ScreenMapper:
@@ -186,7 +190,7 @@ class ScreenMapper:
 
         # Buttons summary (1 line)
         if analysis["buttons"]:
-            button_list = ", ".join(f'"{b}"' for b in analysis["buttons"][:5])
+            button_list = ", ".join(f'"{b}"' for b in analysis["buttons"][:BUTTONS_PREVIEW])
             if len(analysis["buttons"]) > 5:
                 button_list += f" +{len(analysis['buttons']) - 5} more"
             lines.append(f"Buttons: {button_list}")
@@ -216,7 +220,7 @@ class ScreenMapper:
             for elem_type, items in analysis["elements_by_type"].items():
                 if items:  # Only show types that exist
                     lines.append(f"  {elem_type}: {len(items)}")
-                    for item in items[:3]:  # Show first 3
+                    for item in items[:SECTION_ITEMS_PREVIEW]:
                         lines.append(f"    - {item}")
                     if len(items) > 3:
                         lines.append(f"    ... +{len(items) - 3} more")

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/screen_mapper.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/screen_mapper.py
@@ -191,8 +191,8 @@ class ScreenMapper:
         # Buttons summary (1 line)
         if analysis["buttons"]:
             button_list = ", ".join(f'"{b}"' for b in analysis["buttons"][:BUTTONS_PREVIEW])
-            if len(analysis["buttons"]) > 5:
-                button_list += f" +{len(analysis['buttons']) - 5} more"
+            if len(analysis["buttons"]) > BUTTONS_PREVIEW:
+                button_list += f" +{len(analysis['buttons']) - BUTTONS_PREVIEW} more"
             lines.append(f"Buttons: {button_list}")
 
         # Text fields summary (1 line)
@@ -222,8 +222,8 @@ class ScreenMapper:
                     lines.append(f"  {elem_type}: {len(items)}")
                     for item in items[:SECTION_ITEMS_PREVIEW]:
                         lines.append(f"    - {item}")
-                    if len(items) > 3:
-                        lines.append(f"    ... +{len(items) - 3} more")
+                    if len(items) > SECTION_ITEMS_PREVIEW:
+                        lines.append(f"    ... +{len(items) - SECTION_ITEMS_PREVIEW} more")
 
         return "\n".join(lines)
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_boot.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_boot.py
@@ -23,6 +23,11 @@ from common.device_utils import (
     list_simulators,
     resolve_device_identifier,
 )
+from common.env_config import env_float, env_int
+
+DEFAULT_BOOT_TIMEOUT = env_int("IOS_SIM_BOOT_TIMEOUT", 300)
+BOOT_SUBPROCESS_TIMEOUT = env_int("IOS_SIM_BOOT_SUBPROCESS_TIMEOUT", 60)
+POLL_INTERVAL_SECONDS = env_float("IOS_SIM_POLL_INTERVAL", 0.5)
 
 
 class SimulatorBooter:
@@ -32,7 +37,9 @@ class SimulatorBooter:
         """Initialize booter with optional device UDID."""
         self.udid = udid
 
-    def boot(self, wait_ready: bool = False, timeout_seconds: int = 120) -> tuple[bool, str]:
+    def boot(
+        self, wait_ready: bool = False, timeout_seconds: int = DEFAULT_BOOT_TIMEOUT
+    ) -> tuple[bool, str]:
         """
         Boot simulator and optionally wait for readiness.
 
@@ -60,7 +67,13 @@ class SimulatorBooter:
         # Execute boot command
         try:
             cmd = ["xcrun", "simctl", "boot", self.udid]
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=BOOT_SUBPROCESS_TIMEOUT,
+            )
 
             if result.returncode != 0:
                 error = result.stderr.strip()
@@ -84,7 +97,7 @@ class SimulatorBooter:
             "(use --wait-ready to wait for availability)"
         )
 
-    def _wait_for_ready(self, timeout_seconds: int = 120) -> tuple[bool, str]:
+    def _wait_for_ready(self, timeout_seconds: int = DEFAULT_BOOT_TIMEOUT) -> tuple[bool, str]:
         """
         Wait for device to reach ready state.
 
@@ -95,7 +108,7 @@ class SimulatorBooter:
             (success, message) tuple
         """
         start_time = time.time()
-        poll_interval = 0.5
+        poll_interval = POLL_INTERVAL_SECONDS
         checks = 0
 
         while time.time() - start_time < timeout_seconds:
@@ -194,8 +207,11 @@ def main():
     parser.add_argument(
         "--timeout",
         type=int,
-        default=120,
-        help="Timeout for --wait-ready in seconds (default: 120)",
+        default=DEFAULT_BOOT_TIMEOUT,
+        help=(
+            f"Timeout for --wait-ready in seconds "
+            f"(default: {DEFAULT_BOOT_TIMEOUT}, override via IOS_SIM_BOOT_TIMEOUT)"
+        ),
     )
     parser.add_argument(
         "--all",

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_boot.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_boot.py
@@ -27,7 +27,7 @@ from common.env_config import env_float, env_int
 
 DEFAULT_BOOT_TIMEOUT = env_int("IOS_SIM_BOOT_TIMEOUT", 300)
 BOOT_SUBPROCESS_TIMEOUT = env_int("IOS_SIM_BOOT_SUBPROCESS_TIMEOUT", 60)
-POLL_INTERVAL_SECONDS = env_float("IOS_SIM_POLL_INTERVAL", 0.5)
+POLL_INTERVAL_SECONDS = env_float("IOS_SIM_POLL_INTERVAL", 0.5, min_value=0.05)
 
 
 class SimulatorBooter:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_erase.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_erase.py
@@ -23,6 +23,10 @@ from common.device_utils import (
     list_simulators,
     resolve_device_identifier,
 )
+from common.env_config import env_float, env_int
+
+DEFAULT_ERASE_TIMEOUT = env_int("IOS_SIM_ERASE_TIMEOUT", 90)
+POLL_INTERVAL_SECONDS = env_float("IOS_SIM_POLL_INTERVAL", 0.5)
 
 
 class SimulatorEraser:
@@ -32,7 +36,9 @@ class SimulatorEraser:
         """Initialize with optional device UDID."""
         self.udid = udid
 
-    def erase(self, verify: bool = True, timeout_seconds: int = 30) -> tuple[bool, str]:
+    def erase(
+        self, verify: bool = True, timeout_seconds: int = DEFAULT_ERASE_TIMEOUT
+    ) -> tuple[bool, str]:
         """
         Erase simulator and optionally verify completion.
 
@@ -80,7 +86,7 @@ class SimulatorEraser:
             "(use --verify to wait for completion)"
         )
 
-    def _verify_erase(self, timeout_seconds: int = 30) -> tuple[bool, str]:
+    def _verify_erase(self, timeout_seconds: int = DEFAULT_ERASE_TIMEOUT) -> tuple[bool, str]:
         """
         Verify erase has completed.
 
@@ -93,7 +99,7 @@ class SimulatorEraser:
             (success, message) tuple
         """
         start_time = time.time()
-        poll_interval = 0.5
+        poll_interval = POLL_INTERVAL_SECONDS
         checks = 0
 
         while time.time() - start_time < timeout_seconds:
@@ -215,8 +221,11 @@ def main():
     parser.add_argument(
         "--timeout",
         type=int,
-        default=30,
-        help="Timeout for --verify in seconds (default: 30)",
+        default=DEFAULT_ERASE_TIMEOUT,
+        help=(
+            f"Timeout for --verify in seconds "
+            f"(default: {DEFAULT_ERASE_TIMEOUT}, override via IOS_SIM_ERASE_TIMEOUT)"
+        ),
     )
     parser.add_argument(
         "--all",

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_erase.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/simctl_erase.py
@@ -26,7 +26,7 @@ from common.device_utils import (
 from common.env_config import env_float, env_int
 
 DEFAULT_ERASE_TIMEOUT = env_int("IOS_SIM_ERASE_TIMEOUT", 90)
-POLL_INTERVAL_SECONDS = env_float("IOS_SIM_POLL_INTERVAL", 0.5)
+POLL_INTERVAL_SECONDS = env_float("IOS_SIM_POLL_INTERVAL", 0.5, min_value=0.05)
 
 
 class SimulatorEraser:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/xcode/builder.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/xcode/builder.py
@@ -9,8 +9,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+from common.env_config import env_int
+
 from .cache import XCResultCache
 from .config import Config
+
+BUILD_TIMEOUT = env_int("IOS_SIM_BUILD_TIMEOUT", 1800)
+TEST_TIMEOUT = env_int("IOS_SIM_TEST_TIMEOUT", 2700)
+INTROSPECT_TIMEOUT = env_int("IOS_SIM_INTROSPECT_TIMEOUT", 60)
 
 
 class BuildRunner:
@@ -64,7 +70,9 @@ class BuildRunner:
             return None
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=True, timeout=INTROSPECT_TIMEOUT
+            )
 
             # Parse schemes from output
             in_schemes_section = False
@@ -149,6 +157,7 @@ class BuildRunner:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=INTROSPECT_TIMEOUT,
             )
 
             # Check if simulator name appears in available devices
@@ -186,6 +195,7 @@ class BuildRunner:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=INTROSPECT_TIMEOUT,
             )
 
             # Parse available simulators, prefer latest iPhone
@@ -257,7 +267,11 @@ class BuildRunner:
         # Execute build
         try:
             result = subprocess.run(
-                cmd, capture_output=True, text=True, check=False  # Don't raise on non-zero exit
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,  # Don't raise on non-zero exit
+                timeout=BUILD_TIMEOUT,
             )
 
             success = result.returncode == 0
@@ -343,7 +357,9 @@ class BuildRunner:
 
         # Execute tests
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=False, timeout=TEST_TIMEOUT
+            )
 
             success = result.returncode == 0
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/xcode/reporter.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/xcode/reporter.py
@@ -6,6 +6,12 @@ Provides multiple output formats with progressive disclosure support.
 
 import json
 
+from common.env_config import env_int
+
+BUILD_SUMMARY_CAP = env_int("IOS_SIM_BUILD_SUMMARY_CAP", 15)
+BUILD_VERBOSE_CAP = env_int("IOS_SIM_BUILD_VERBOSE_CAP", 100)
+BUILD_LOG_TAIL = env_int("IOS_SIM_LOG_TAIL", 200)
+
 
 class OutputFormatter:
     """
@@ -66,12 +72,14 @@ class OutputFormatter:
         # Surface errors inline on failure
         if status == "FAILED" and errors:
             lines.append("")
-            lines.append(OutputFormatter.format_errors(errors, limit=5))
+            lines.append(OutputFormatter.format_errors(errors, limit=BUILD_SUMMARY_CAP))
 
         # Surface failed tests inline on failure
         if failed_tests:
             lines.append("")
-            lines.append(OutputFormatter.format_test_failures(failed_tests, limit=5))
+            lines.append(
+                OutputFormatter.format_test_failures(failed_tests, limit=BUILD_SUMMARY_CAP)
+            )
 
         # Add hints if provided and build failed
         if hints and status == "FAILED":
@@ -81,7 +89,7 @@ class OutputFormatter:
         return "\n".join(lines)
 
     @staticmethod
-    def format_test_failures(failed_tests: list[dict], limit: int = 5) -> str:
+    def format_test_failures(failed_tests: list[dict], limit: int = BUILD_SUMMARY_CAP) -> str:
         """
         Format failed test details.
 
@@ -112,7 +120,7 @@ class OutputFormatter:
         return "\n".join(lines)
 
     @staticmethod
-    def format_errors(errors: list[dict], limit: int = 10) -> str:
+    def format_errors(errors: list[dict], limit: int = BUILD_VERBOSE_CAP) -> str:
         """
         Format error details.
 
@@ -153,7 +161,7 @@ class OutputFormatter:
         return "\n".join(lines)
 
     @staticmethod
-    def format_warnings(warnings: list[dict], limit: int = 10) -> str:
+    def format_warnings(warnings: list[dict], limit: int = BUILD_VERBOSE_CAP) -> str:
         """
         Format warning details.
 
@@ -194,7 +202,7 @@ class OutputFormatter:
         return "\n".join(lines)
 
     @staticmethod
-    def format_log(log: str, lines: int = 50) -> str:
+    def format_log(log: str, lines: int = BUILD_LOG_TAIL) -> str:
         """
         Format build log (show last N lines).
 
@@ -321,12 +329,12 @@ class OutputFormatter:
 
         # Errors
         if errors and len(errors) > 0:
-            lines.append(OutputFormatter.format_errors(errors, limit=5))
+            lines.append(OutputFormatter.format_errors(errors, limit=BUILD_VERBOSE_CAP))
             lines.append("")
 
         # Warnings
         if warnings and len(warnings) > 0:
-            lines.append(OutputFormatter.format_warnings(warnings, limit=5))
+            lines.append(OutputFormatter.format_warnings(warnings, limit=BUILD_VERBOSE_CAP))
             lines.append("")
 
         # Summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ios-simulator-skill"
-version = "1.4.2"
+version = "1.5.0"
 description = "Build, test, and automate iOS apps with accessibility-driven navigation"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Audit-driven pass over baked-in constants chosen when the project was small. With 1000+ users now hitting slow CI runners, monorepo builds, and accessibility audits on complex screens, several defaults were silently truncating diagnostics or timing out.

**Strategy**: bump conservative defaults AND expose env-var overrides for the highest-traffic knobs. No new CLI flags. 23 \`IOS_SIM_*\` variables documented in SKILL.md + README.md.

## Highlights

| Area | Was | Now | Env override |
|---|---|---|---|
| Boot wait-ready | 120s | **300s** | \`IOS_SIM_BOOT_TIMEOUT\` |
| Erase verify | 30s | **90s** | \`IOS_SIM_ERASE_TIMEOUT\` |
| Log JSON error/warning cap | 20 | **100** | \`IOS_SIM_LOG_JSON_CAP\` |
| Log tail (verbose / sample) | 50 lines | **200** | \`IOS_SIM_LOG_TAIL\` |
| Per-log-line truncation | 120 chars | **300** | \`IOS_SIM_LOG_LINE_MAX\` |
| Build verbose error cap | 10 | **100** | \`IOS_SIM_BUILD_VERBOSE_CAP\` |
| Build JSON failure cap | 10 | **50** | \`IOS_SIM_BUILD_JSON_CAP\` |
| Navigator tappables listed | 10 | **25** | \`IOS_SIM_MAX_ELEMENTS\` |
| Screen mapper buttons | 5 | **15** | \`IOS_SIM_SCREEN_BUTTONS_PREVIEW\` |
| A11y top issues | 3 | **10** | \`IOS_SIM_A11Y_TOP_ISSUES\` |
| A11y label truncation | 30 chars | **80** | \`IOS_SIM_A11Y_LABEL_MAX\` |
| Cache TTL | 1h | 1h | \`IOS_SIM_CACHE_TTL_HOURS\` |
| Cache size | unbounded | **500 LRU** | \`IOS_SIM_CACHE_MAX_ENTRIES\` |

Full table in [SKILL.md → Configuration](https://github.com/conorluddy/ios-simulator-skill/blob/chore/configurable-limits-v1.5/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md#configuration).

## New file

\`scripts/common/env_config.py\` — tiny \`env_int\` / \`env_float\` helpers with parse-error fallback and minimum-value clamping. ~35 lines.

## Verification

- \`black --check\` and \`ruff check\` clean on the full \`scripts/\` tree.
- All 9 touched modules import cleanly.
- LRU eviction verified end-to-end: 15 writes into a \`max_entries=10\` temp cache → 10 retained.
- Env override verified: \`IOS_SIM_BOOT_TIMEOUT=600 simctl_boot.py --help\` reflects \`default: 600\`.
- Doc/code sync: \`diff\` of \`IOS_SIM_*\` grepped from code vs. SKILL.md table is empty.

## Version

Bumped to \`1.5.0\` in \`pyproject.toml\` and \`SKILL.md\` frontmatter.

## Out of scope

CLI flags for these knobs (env vars only this pass), gesture/keyboard inter-action delays, JPEG quality.