### PR TITLE
chore: SKILL.md + README sweep for v2.0 wave 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code and developers working with this repo
 iOS Simulator Skill is a production-ready Agent Skill providing 21 scripts for iOS app building, testing, and automation. It wraps Apple's `xcrun simctl` and Facebook's `idb` tools with semantic interfaces designed for AI agents and developers.
 
 **Key Statistics:**
-- 22 production scripts (~8,500 lines)
+- 27 production scripts (~8,500 lines)
 - 5 script categories (Build, Navigation, Testing, Permissions, Lifecycle)
 - 6 shared utility modules (~1,400 lines)
 - 100% token-optimized default output
@@ -23,7 +23,7 @@ ios-simulator-skill/            # Repository root
 │   └── skills/
 │       └── ios-simulator-skill/
 │           ├── SKILL.md       # Entry point (table of contents)
-│           └── scripts/       # 22 production scripts
+│           └── scripts/       # 27 production scripts
 │               ├── build_and_test.py
 │               ├── xcode/     # Xcode integration module
 │               ├── log_monitor.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # iOS Simulator Skill for Claude Code
 
-Production-ready skill for building, testing, and automating iOS apps. 22 scripts optimized for both human developers and AI agents.
+Production-ready skill for building, testing, and automating iOS apps. 27 scripts optimized for both human developers and AI agents.
 
 ## Xcode Build + Simulator Automation
 
@@ -80,7 +80,7 @@ The accessibility tree gives structured data (element types, labels, frames, tap
 
 ### Screenshot Token Optimization
 
-When screenshots are needed (visual verification, bug reports, diffs), the skill automatically resizes and compresses them to minimize token cost. Default output across all 22 scripts is 3-5 lines — 96% reduction vs raw tool output.
+When screenshots are needed (visual verification, bug reports, diffs), the skill automatically resizes and compresses them to minimize token cost. Default output across all 27 scripts is 3-5 lines — 96% reduction vs raw tool output.
 
 | Task | Raw Tools | This Skill | Savings |
 |------|-----------|-----------|---------|
@@ -88,7 +88,7 @@ When screenshots are needed (visual verification, bug reports, diffs), the skill
 | Find & tap button | 100+ lines | 1 line | 99% |
 | Login flow | 400+ lines | 15 lines | 96% |
 
-### All 22 Scripts
+### All 27 Scripts
 
 Every script supports `--help` and `--json`. See **SKILL.md** for the complete reference.
 
@@ -98,6 +98,13 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 |--------|-------------|-----------|
 | `build_and_test.py` | Build Xcode projects, run tests, parse xcresult bundles | `--project`, `--scheme`, `--test`, `--get-errors`, `--get-warnings` |
 | `log_monitor.py` | Real-time log monitoring with severity filtering | `--app`, `--severity`, `--follow`, `--duration` |
+
+#### Device State
+
+| Script | What it does | Key flags |
+|--------|-------------|-----------|
+| `appearance.py` | Switch dark mode, dynamic type, locale, region | `--theme`, `--text-size`, `--locale`, `--region`, `--reset` |
+| `location.py` | Simulate GPS coordinates and run built-in scenarios | `--lat/--lng`, `--city`, `--gpx`, `--list-scenarios`, `--clear` |
 
 #### Navigation & Interaction
 
@@ -119,6 +126,9 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 | `app_state_capture.py` | Debugging snapshots (screenshot, hierarchy, logs) | `--app-bundle-id`, `--output`, `--log-lines` |
 | `sim_health_check.sh` | Verify environment (Xcode, simctl, IDB, Python) | — |
 | `model_inspector.py` | Inspect Core Data / SwiftData models from project files | `--project-path`, `--raw`, `--show-versions` |
+| `container.py` | Inspect app sandbox: list, cat, UserDefaults, Core Data, export | `--ls`, `--cat`, `--userdefaults`, `--core-data-path`, `--export` |
+| `hang_watcher.py` | Stream `os_log` hang events with structured output | `--watch`, `--bundle-id`, `--since`, `--predicate` |
+| `localization_audit.py` | Audit `.xcstrings` catalogs for missing keys, unused keys, placeholder mismatches | `--catalog`, `--source`, `--strict` |
 
 #### Permissions & Environment
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ How long to wait on `xcrun simctl` operations.
 | `IOS_SIM_LOG_LINE_MAX` | `300` (chars) | Per-line truncation. Crash messages with full Swift symbol mangling can exceed 200 chars; raise if you see “…” cutting off the actionable bit. |
 | `IOS_SIM_LOG_TAIL` | `200` (lines) | Recent log lines shown in verbose mode and JSON `sample_logs`. Also used by xcode log excerpt. Lower for tighter context, higher for richer post-mortems. |
 | `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors / warnings in JSON output. Raise if you're piping into a dashboard that needs the full picture. |
+| `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py`. The default catches RunningBoard watchdog kills, explicit "Hang detected" messages, and main-thread hang annotations. Narrow it (e.g. `subsystem == "com.apple.runningboard"`) for major-hangs-only; broaden for noisier subsystems. |
 
 ### UI navigation & screen mapping
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 | Script | What it does | Key flags |
 |--------|-------------|-----------|
 | `appearance.py` | Switch dark mode, dynamic type, locale, region | `--theme`, `--text-size`, `--locale`, `--region`, `--reset` |
-| `location.py` | Simulate GPS coordinates and run built-in scenarios | `--lat/--lng`, `--city`, `--gpx`, `--list-scenarios`, `--clear` |
+| `location.py` | Simulate GPS coordinates and run built-in scenarios | `--lat`, `--lng`, `--city`, `--gpx`, `--list-scenarios`, `--clear` |
 
 #### Navigation & Interaction
 
@@ -127,7 +127,7 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 | `sim_health_check.sh` | Verify environment (Xcode, simctl, IDB, Python) | — |
 | `model_inspector.py` | Inspect Core Data / SwiftData models from project files | `--project-path`, `--raw`, `--show-versions` |
 | `container.py` | Inspect app sandbox: list, cat, UserDefaults, Core Data, export | `--ls`, `--cat`, `--userdefaults`, `--core-data-path`, `--export` |
-| `hang_watcher.py` | Stream `os_log` hang events with structured output | `--watch`, `--bundle-id`, `--since`, `--predicate` |
+| `hang_watcher.py` | Stream and record `os_log` hang events from a live simulator | `--watch`, `--bundle-id`, `--since`, `--predicate` |
 | `localization_audit.py` | Audit `.xcstrings` catalogs for missing keys, unused keys, placeholder mismatches | `--catalog`, `--source`, `--strict` |
 
 #### Permissions & Environment

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ios-simulator-skill
 version: 1.5.0
-description: 22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
+description: 27 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
 ---
 
 # iOS Simulator Skill
@@ -40,7 +40,7 @@ Use this priority:
 
 Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree costs 10–50 tokens in default mode.
 
-## 22 Production Scripts
+## 27 Production Scripts
 
 ### Build & Development (2 scripts)
 
@@ -56,22 +56,38 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
    - Deduplicate repeated messages
    - Options: `--app`, `--severity`, `--follow`, `--duration`, `--output`, `--json`
 
+### Device State (2 scripts)
+
+3. **appearance.py** - Control simulator appearance: dark mode, Dynamic Type size, and locale/region
+   - Toggle light/dark theme via `xcrun simctl ui`
+   - Set Dynamic Type size with friendly aliases (XS through AX5)
+   - Write locale and region defaults; optional app restart via `--bundle-id`
+   - RTL flagged automatically for ar/he/fa/ur/yi locales
+   - Options: `--theme`, `--text-size`, `--locale`, `--region`, `--reset`, `--bundle-id`, `--udid`, `--json`, `--verbose`
+
+4. **location.py** - Simulate GPS coordinates, named city presets, and GPX scenario playback
+   - Fix a coordinate with `--lat`/`--lng` or pick a city with `--city`
+   - Play a built-in scenario (City Run, Freeway Drive, etc.) via `--gpx <scenario>`
+   - Animate multi-waypoint paths with configurable speed via `--waypoints` and `--speed`
+   - Clear simulated location with `--clear`; list available scenarios with `--list-scenarios`
+   - Options: `--lat`, `--lng`, `--city`, `--gpx`, `--waypoints`, `--speed`, `--clear`, `--list-scenarios`, `--udid`, `--json`, `--verbose`
+
 ### Navigation & Interaction (5 scripts)
 
-3. **screen_mapper.py** - Analyze current screen and list interactive elements
+5. **screen_mapper.py** - Analyze current screen and list interactive elements
    - Element type breakdown
    - Interactive button list
    - Text field status
    - Options: `--verbose`, `--hints`, `--json`
 
-4. **navigator.py** - Find and interact with elements semantically
+6. **navigator.py** - Find and interact with elements semantically
    - Find by text (fuzzy matching)
    - Find by element type
    - Find by accessibility ID
    - Enter text or tap elements
    - Options: `--find-text`, `--find-type`, `--find-id`, `--tap`, `--enter-text`, `--json`
 
-5. **gesture.py** - Perform swipes, scrolls, pinches, and complex gestures
+7. **gesture.py** - Perform swipes, scrolls, pinches, and complex gestures
    - Directional swipes (up/down/left/right)
    - Multi-swipe scrolling
    - Pinch zoom
@@ -79,14 +95,14 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
    - Pull to refresh
    - Options: `--swipe`, `--scroll`, `--pinch`, `--long-press`, `--refresh`, `--json`
 
-6. **keyboard.py** - Text input and hardware button control
+8. **keyboard.py** - Text input and hardware button control
    - Type text (fast or slow)
    - Special keys (return, delete, tab, space, arrows)
    - Hardware buttons (home, lock, volume, screenshot)
    - Key combinations
    - Options: `--type`, `--key`, `--button`, `--slow`, `--clear`, `--dismiss`, `--json`
 
-7. **app_launcher.py** - App lifecycle management
+9. **app_launcher.py** - App lifecycle management
    - Launch apps by bundle ID
    - Terminate apps
    - Install/uninstall from .app bundles
@@ -95,61 +111,85 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
    - Check app state
    - Options: `--launch`, `--terminate`, `--install`, `--uninstall`, `--open-url`, `--list`, `--state`, `--json`
 
-### Testing & Analysis (6 scripts)
+### Testing & Analysis (9 scripts)
 
-8. **accessibility_audit.py** - Check WCAG compliance on current screen
-   - Critical issues (missing labels, empty buttons, no alt text)
-   - Warnings (missing hints, small touch targets)
-   - Info (missing IDs, deep nesting)
-   - Options: `--verbose`, `--output`, `--json`
+10. **accessibility_audit.py** - Check WCAG compliance on current screen
+    - Critical issues (missing labels, empty buttons, no alt text)
+    - Warnings (missing hints, small touch targets)
+    - Info (missing IDs, deep nesting)
+    - Options: `--verbose`, `--output`, `--json`
 
-9. **visual_diff.py** - Compare two screenshots for visual changes
-   - Pixel-by-pixel comparison
-   - Threshold-based pass/fail
-   - Generate diff images
-   - Options: `--threshold`, `--output`, `--details`, `--json`
+11. **visual_diff.py** - Compare two screenshots for visual changes
+    - Pixel-by-pixel comparison
+    - Threshold-based pass/fail
+    - Generate diff images
+    - Options: `--threshold`, `--output`, `--details`, `--json`
 
-10. **test_recorder.py** - Automatically document test execution
+12. **test_recorder.py** - Automatically document test execution
     - Capture screenshots and accessibility trees per step
     - Generate markdown reports with timing data
     - Options: `--test-name`, `--output`, `--verbose`, `--json`
 
-11. **app_state_capture.py** - Create comprehensive debugging snapshots
+13. **app_state_capture.py** - Create comprehensive debugging snapshots
     - Screenshot, UI hierarchy, app logs, device info
     - Markdown summary for bug reports
     - Options: `--app-bundle-id`, `--output`, `--log-lines`, `--json`
 
-12. **sim_health_check.sh** - Verify environment is properly configured
+14. **sim_health_check.sh** - Verify environment is properly configured
     - Check macOS, Xcode, simctl, IDB, Python
     - List available and booted simulators
     - Verify Python packages (Pillow)
 
-13. **model_inspector.py** - Inspect Core Data and SwiftData models from project files
+15. **model_inspector.py** - Inspect Core Data and SwiftData models from project files
     - Parse .xcdatamodeld packages (entities, attributes, relationships)
     - Detect model versions and current active version
     - Best-effort SwiftData @Model class extraction
     - Raw source dump for any model on demand (`--raw ModelName`)
     - Options: `--project-path`, `--core-data-only`, `--swiftdata-only`, `--show-versions`, `--raw`, `--verbose`, `--json`
 
+16. **container.py** - Inspect app sandbox: files, UserDefaults, and Core Data store paths
+    - List data container files at configurable depth via `--ls`
+    - Read files with auto-detected plist decoding via `--cat` (large files cached)
+    - Dump UserDefaults as key=value or JSON via `--userdefaults`
+    - Locate `.sqlite` / `.sqlite-wal` / `.sqlite-shm` stores via `--core-data-path`
+    - Export full container snapshot via `--export`
+    - Options: `--ls`, `--cat`, `--userdefaults`, `--core-data-path`, `--export`, `--udid`, `--json`, `--verbose`
+
+17. **hang_watcher.py** - Stream and record os_log hang events from a live simulator
+    - Watch for main-thread hangs via a targeted `log stream` predicate
+    - Query historical events with `--since` (e.g. `--since 5m`)
+    - Filter to a specific app with `--bundle-id`
+    - Override predicate via `IOS_SIM_HANG_PREDICATE` env var or `--predicate`
+    - Hang archive saved to ProgressiveCache on exit; `duration_estimate_ms` parsed from messages
+    - Options: `--watch`, `--duration`, `--since`, `--bundle-id`, `--predicate`, `--udid`, `--json`, `--verbose`
+
+18. **localization_audit.py** - Detect string catalog gaps, missing keys, and placeholder mismatches
+    - Report missing and `needs_review`/`new` keys per locale in `.xcstrings` catalogs
+    - Cross-reference catalog keys against Swift source (`String(localized:)` / `NSLocalizedString`) via `--source`
+    - Flag placeholder count mismatches (`%d`, `%@`, `%s`, `%lld`) across locales
+    - Legacy `.strings` and `.stringsdict` support via `plistlib`
+    - CI-friendly `--strict` exits 2 on any finding
+    - Options: `--catalog`, `--source`, `--locale`, `--strict`, `--json`, `--verbose`
+
 ### Advanced Testing & Permissions (4 scripts)
 
-14. **clipboard.py** - Manage simulator clipboard for paste testing
+19. **clipboard.py** - Manage simulator clipboard for paste testing
     - Copy text to clipboard
     - Test paste flows without manual entry
     - Options: `--copy`, `--test-name`, `--expected`, `--json`
 
-15. **status_bar.py** - Override simulator status bar appearance
+20. **status_bar.py** - Override simulator status bar appearance
     - Presets: clean (9:41, 100% battery), testing (11:11, 50%), low-battery (20%), airplane (offline)
     - Custom time, network, battery, WiFi settings
     - Options: `--preset`, `--time`, `--data-network`, `--battery-level`, `--clear`, `--json`
 
-16. **push_notification.py** - Send simulated push notifications
+21. **push_notification.py** - Send simulated push notifications
     - Simple mode (title + body + badge)
     - Custom JSON payloads
     - Test notification handling and deep links
     - Options: `--bundle-id`, `--title`, `--body`, `--badge`, `--payload`, `--json`
 
-17. **privacy_manager.py** - Grant, revoke, and reset app permissions
+22. **privacy_manager.py** - Grant, revoke, and reset app permissions
     - 13 supported services (camera, microphone, location, contacts, photos, calendar, health, etc.)
     - Batch operations (comma-separated services)
     - Audit trail with test scenario tracking
@@ -157,34 +197,34 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
 
 ### Device Lifecycle Management (5 scripts)
 
-18. **simctl_boot.py** - Boot simulators with optional readiness verification
+23. **simctl_boot.py** - Boot simulators with optional readiness verification
     - Boot by UDID or device name
     - Wait for device ready with timeout
     - Batch boot operations (--all, --type)
     - Performance timing
     - Options: `--udid`, `--name`, `--wait-ready`, `--timeout`, `--all`, `--type`, `--json`
 
-19. **simctl_shutdown.py** - Gracefully shutdown simulators
+24. **simctl_shutdown.py** - Gracefully shutdown simulators
     - Shutdown by UDID or device name
     - Optional verification of shutdown completion
     - Batch shutdown operations
     - Options: `--udid`, `--name`, `--verify`, `--timeout`, `--all`, `--type`, `--json`
 
-20. **simctl_create.py** - Create simulators dynamically
+25. **simctl_create.py** - Create simulators dynamically
     - Create by device type and iOS version
     - List available device types and runtimes
     - Custom device naming
     - Returns UDID for CI/CD integration
     - Options: `--device`, `--runtime`, `--name`, `--list-devices`, `--list-runtimes`, `--json`
 
-21. **simctl_delete.py** - Permanently delete simulators
+26. **simctl_delete.py** - Permanently delete simulators
     - Delete by UDID or device name
     - Safety confirmation by default (skip with --yes)
     - Batch delete operations
     - Smart deletion (--old N to keep N per device type)
     - Options: `--udid`, `--name`, `--yes`, `--all`, `--type`, `--old`, `--json`
 
-22. **simctl_erase.py** - Factory reset simulators without deletion
+27. **simctl_erase.py** - Factory reset simulators without deletion
     - Preserve device UUID (faster than delete+create)
     - Erase all, by type, or booted simulators
     - Optional verification

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -274,6 +274,7 @@ Most operational limits can be tuned via environment variables. Defaults work fo
 | `IOS_SIM_CACHE_MAX_ENTRIES` | `500` | Max entries in progressive disclosure cache (LRU eviction) |
 | `IOS_SIM_CACHE_TTL_HOURS` | `1` | Cache entry expiration |
 | `IOS_SIM_ERASE_TIMEOUT` | `90` | Wait-for-erase timeout (seconds) |
+| `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py` (default catches RunningBoard kills + "Hang detected" + main-thread hangs) |
 | `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors/warnings in `log_monitor.py` JSON output |
 | `IOS_SIM_LOG_LINE_MAX` | `300` | Per-line truncation in log summaries |
 | `IOS_SIM_LOG_TAIL` | `200` | Lines of log tail in verbose / sample output |


### PR DESCRIPTION
Documentation sweep for the 5 new scripts added in PRs #71, #72, #73, #74, #75.

## SKILL.md changes
- Bump `## 22 Production Scripts` → `## 27 Production Scripts`
- New **Device State (2 scripts)** subsection: `appearance.py`, `location.py`
- **Testing & Analysis** bumped `(6 scripts) → (9 scripts)` with entries for `container.py`, `hang_watcher.py`, `localization_audit.py`
- Existing script numbers renumbered 3–22 → 3–27

## README.md changes
- Same `22 → 27` bumps in 3 places (subtitle, screenshot section, scripts header)
- New **Device State** subsection mirroring SKILL.md
- 3 new entries under Testing & Analysis

## Known follow-up
The hang predicate env var `IOS_SIM_HANG_PREDICATE` (introduced in PR #75) needs to be added to the Configuration env var table — but that table only exists on the unmerged PR #53 branch. Add post-merge.

Should merge **after** PRs #71–#75.

Refs #54 #55 #57 #60 #68.