### PR TITLE
feat: HangBuster — session-scoped recorder with progressive disclosure (#77)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,9 +3,7 @@
   "owner": {
     "name": "Conor Luddy"
   },
-  "metadata": {
-    "description": "iOS simulator automation skills for Claude Code"
-  },
+  "description": "iOS simulator automation skills for Claude Code",
   "plugins": [
     {
       "name": "ios-simulator-skill",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ This file provides guidance to Claude Code and developers working with this repo
 iOS Simulator Skill is a production-ready Agent Skill providing 21 scripts for iOS app building, testing, and automation. It wraps Apple's `xcrun simctl` and Facebook's `idb` tools with semantic interfaces designed for AI agents and developers.
 
 **Key Statistics:**
-- 27 production scripts (~8,500 lines)
+- 27 production scripts (~9,000 lines)
 - 5 script categories (Build, Navigation, Testing, Permissions, Lifecycle)
-- 6 shared utility modules (~1,400 lines)
+- 7 shared utility modules (~2,400 lines)
 - 100% token-optimized default output
-- Full test coverage on all new features
+- 88 unit tests across pipeline / sessions / token-budget / diff (run `pytest tests/`)
 
 ## Project Structure
 
@@ -27,6 +27,7 @@ ios-simulator-skill/            # Repository root
 │               ├── build_and_test.py
 │               ├── xcode/     # Xcode integration module
 │               ├── log_monitor.py
+│               ├── hang_watcher.py    # HangBuster session recorder + legacy stream
 │               ├── screen_mapper.py
 │               ├── navigator.py
 │               ├── gesture.py
@@ -47,6 +48,8 @@ ios-simulator-skill/            # Repository root
 │               ├── simctl_erase.py
 │               ├── sim_health_check.sh
 │               └── common/    # Shared utilities
+│                   ├── hang_pipeline.py   # HangBuster filter pipeline (pure fns)
+│                   └── hang_sessions.py   # HangBuster session storage
 ├── .github/workflows/
 ├── pyproject.toml
 └── README.md
@@ -126,12 +129,13 @@ python scripts/simctl_boot.py --type iPhone
 - **keyboard.py**: Text input and keys
 - **app_launcher.py**: App lifecycle
 
-### Testing & Analysis (5)
+### Testing & Analysis (6)
 - **accessibility_audit.py**: WCAG compliance
 - **visual_diff.py**: Screenshot comparison
 - **test_recorder.py**: Test documentation
 - **app_state_capture.py**: Debugging snapshots
 - **sim_health_check.sh**: Environment verification
+- **hang_watcher.py** (HangBuster): session-scoped hang recorder with progressive disclosure (`--start`/`--stop`/`--get-details`/`--diff`); legacy `--watch`/`--since` paths preserved
 
 ### Advanced Testing & Permissions (4)
 - **clipboard.py**: Clipboard management
@@ -160,6 +164,22 @@ python scripts/simctl_boot.py --type iPhone
 
 ### cache_utils.py (~258 lines)
 - `ProgressiveCache`: Large output caching with TTL
+
+### hang_pipeline.py (~630 lines)
+Pure-function HangBuster filter pipeline (parse → normalise → threshold → bucket → cluster → aggregate → rank → format). Reusable but scoped — promote to a generic `log_filters.py` only when a second consumer appears (AHA).
+
+- `parse_log_line()`, `normalise_message()`, `bucket_severity()`, `compute_fingerprint()`
+- `cluster_events()`, `rank_clusters()`, aggregators (bursts/quiet/process)
+- `format_l0/l1/l2()`, `format_cluster_detail()`, `format_diff()`
+- `estimate_tokens()` (char/4 heuristic), `compress_to_budget()`
+- `diff_sessions()` with `fingerprint_version` guard
+- Dataclasses: `NormalisedEvent`, `Cluster`, `SessionSummary`, `Severity` (StrEnum)
+
+### hang_sessions.py (~355 lines)
+- `SessionStore`: filesystem-backed session repository at `~/.ios-simulator-skill/sessions/<id>/{meta.json, events.jsonl, summary.json}`
+- Session ID format: `hang-YYYYMMDD-HHmmss-<4hex>` (random suffix avoids same-second collisions)
+- Atomic meta writes (`.tmp` + `replace`); worker writes its own pid (no pidfile race)
+- TTL prune via `IOS_SIM_HANG_SESSION_TTL_HOURS` on every `--start`
 
 ## Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 | `sim_health_check.sh` | Verify environment (Xcode, simctl, IDB, Python) | — |
 | `model_inspector.py` | Inspect Core Data / SwiftData models from project files | `--project-path`, `--raw`, `--show-versions` |
 | `container.py` | Inspect app sandbox: list, cat, UserDefaults, Core Data, export | `--ls`, `--cat`, `--userdefaults`, `--core-data-path`, `--export` |
-| `hang_watcher.py` | Stream and record `os_log` hang events from a live simulator | `--watch`, `--bundle-id`, `--since`, `--predicate` |
+| `hang_watcher.py` (HangBuster) | Record + summarise `os_log` hang events with progressive disclosure (session mode + legacy stream) | `--start`, `--stop`, `--get-details`, `--list-sessions`, `--diff`, `--budget-tokens`, `--auto-sample` (legacy: `--watch`, `--since`) |
 | `localization_audit.py` | Audit `.xcstrings` catalogs for missing keys, unused keys, placeholder mismatches | `--catalog`, `--source`, `--strict` |
 
 #### Permissions & Environment
@@ -195,6 +195,10 @@ How long to wait on `xcrun simctl` operations.
 | `IOS_SIM_LOG_TAIL` | `200` (lines) | Recent log lines shown in verbose mode and JSON `sample_logs`. Also used by xcode log excerpt. Lower for tighter context, higher for richer post-mortems. |
 | `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors / warnings in JSON output. Raise if you're piping into a dashboard that needs the full picture. |
 | `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py`. The default catches RunningBoard watchdog kills, explicit "Hang detected" messages, and main-thread hang annotations. Narrow it (e.g. `subsystem == "com.apple.runningboard"`) for major-hangs-only; broaden for noisier subsystems. |
+| `IOS_SIM_HANG_MIN_MS` | `250` | HangBuster threshold: events below this duration never reach disk. |
+| `IOS_SIM_HANG_SESSION_TTL_HOURS` | `24` | HangBuster session prune age. |
+| `IOS_SIM_HANG_DEFAULT_TOP_N` | `3` | Default top-N clusters in `--stop` L1 output. |
+| `IOS_SIM_HANG_BUDGET_TOKENS` | _(unset)_ | Default token budget for `--stop` (picks L0/L1/L2 to fit). |
 
 ### UI navigation & screen mapping
 

--- a/ios-simulator-skill/.claude-plugin/plugin.json
+++ b/ios-simulator-skill/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "ios-simulator-skill",
-  "version": "1.4.2",
   "description": "22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
   "author": {
     "name": "Conor Luddy"

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -155,13 +155,18 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
     - Export full container snapshot via `--export`
     - Options: `--ls`, `--cat`, `--userdefaults`, `--core-data-path`, `--export`, `--udid`, `--json`, `--verbose`
 
-17. **hang_watcher.py** - Stream and record os_log hang events from a live simulator
-    - Watch for main-thread hangs via a targeted `log stream` predicate
-    - Query historical events with `--since` (e.g. `--since 5m`)
-    - Filter to a specific app with `--bundle-id`
-    - Override predicate via `IOS_SIM_HANG_PREDICATE` env var or `--predicate`
-    - Hang archive saved to ProgressiveCache on exit; `duration_estimate_ms` parsed from messages
-    - Options: `--watch`, `--duration`, `--since`, `--bundle-id`, `--predicate`, `--udid`, `--json`, `--verbose`
+17. **hang_watcher.py** (HangBuster) - Record + summarise os_log hang events with progressive disclosure
+    - **Session mode (HangBuster, agent-native):** start a detached recorder, interact with the simulator, stop for a token-tight summary
+      - `--start` → returns a session ID; detached worker normalises + thresholds events on the fly
+      - `--stop SESSION_ID` → emits ~80–120 token L1 summary (header + top-N clusters + drill hint)
+      - `--get-details SESSION_ID [--cluster N | --raw]` → L2 full clusters or L3 per-event detail
+      - `--list-sessions` / `--clear-sessions [--older-than 24h]` / `--diff A B` (cross-session regression report)
+      - Filter pipeline: parse → normalise → threshold → bucket → cluster → aggregate → rank → format (in `common/hang_pipeline.py`)
+      - `--budget-tokens N` picks the densest level (L0/L1/L2) that fits; `--terse` forces L0
+      - `--auto-sample` captures a main-thread stack on first event per cluster (soft dependency: `main_thread_sampler.py` #62; graceful no-op if absent)
+    - **Legacy modes (unchanged for backward compat):** `--watch [--duration N]` (live stream) and `--since 5m` (historical)
+    - Filters: `--bundle-id`, `--predicate` (also via `IOS_SIM_HANG_PREDICATE`)
+    - All output supports `--json`; session storage at `~/.ios-simulator-skill/sessions/<id>/{meta.json,events.jsonl,summary.json}`
 
 18. **localization_audit.py** - Detect string catalog gaps, missing keys, and placeholder mismatches
     - Report missing and `needs_review`/`new` keys per locale in `.xcstrings` catalogs
@@ -275,6 +280,10 @@ Most operational limits can be tuned via environment variables. Defaults work fo
 | `IOS_SIM_CACHE_TTL_HOURS` | `1` | Cache entry expiration |
 | `IOS_SIM_ERASE_TIMEOUT` | `90` | Wait-for-erase timeout (seconds) |
 | `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py` (default catches RunningBoard kills + "Hang detected" + main-thread hangs) |
+| `IOS_SIM_HANG_MIN_MS` | `250` | HangBuster threshold — events below this duration never reach disk (smaller = more sensitive, larger summaries) |
+| `IOS_SIM_HANG_SESSION_TTL_HOURS` | `24` | HangBuster session prune age; pruning runs on every `--start` |
+| `IOS_SIM_HANG_DEFAULT_TOP_N` | `3` | Default top-N clusters in `--stop` L1 output |
+| `IOS_SIM_HANG_BUDGET_TOKENS` | _(unset)_ | Default token budget for `--stop` (picks L0/L1/L2 to fit) |
 | `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors/warnings in `log_monitor.py` JSON output |
 | `IOS_SIM_LOG_LINE_MAX` | `300` | Per-line truncation in log summaries |
 | `IOS_SIM_LOG_TAIL` | `200` | Lines of log tail in verbose / sample output |

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
@@ -1,0 +1,768 @@
+#!/usr/bin/env python3
+"""HangBuster filter pipeline — pure functions, no I/O.
+
+Stages: parse → normalise → threshold → bucket → cluster → aggregate → rank → format.
+
+Each function is independently testable; the worker and the `--stop` path both
+compose them. Scoped to hang detection for now (AHA — promote to a generic
+log-filter module when a second consumer needs it).
+
+Token budgets are enforced via a documented char/4 heuristic
+(`estimate_tokens`) — accurate to within ~10% of real tokenizers and
+dependency-free.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import math
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import StrEnum
+
+# === CONSTANTS ===
+
+FINGERPRINT_VERSION = 1
+"""Bump when normalise_message, compute_fingerprint, or severity boundaries change.
+`--diff` skips structural comparison across mismatched versions."""
+
+_HEX_ADDR = re.compile(r"0x[0-9a-fA-F]{4,}")
+_PID_REF = re.compile(r"\bpid[:= ]\s*\d+\b", re.IGNORECASE)
+_BARE_INT = re.compile(r"\b\d{4,}\b")
+_WHITESPACE = re.compile(r"\s+")
+_BOILERPLATE_PREFIXES = (
+    "Hang detected by RunningBoard:",
+    "Hang detected:",
+    "[RunningBoard]",
+)
+_SYMBOL_PATTERNS = [
+    re.compile(r"([+-]?\[[A-Za-z_][\w]*\s+[A-Za-z_][\w:]*\])"),  # [Foo bar:] / +[Foo bar:]
+    re.compile(r"\b([A-Z][A-Za-z0-9_]+\.[A-Za-z_][\w]+(?:\([^)]*\))?)\b"),  # Swift Foo.bar()
+]
+
+_LOG_LINE_PATTERN = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d+(?:[+-]\d{4})?)"
+    r"\s+0x[\da-f]+"
+    r"\s+\S+"
+    r"\s+0x[\da-f]+"
+    r"\s+(\d+)"
+    r"\s+\d+"
+    r"\s+([^:]+):"
+    r"\s*(.*)",
+    re.IGNORECASE,
+)
+
+_DURATION_PATTERNS = [
+    # Order matters: ms before s, so "487ms" doesn't get parsed as 487 seconds.
+    re.compile(r"(\d+(?:\.\d+)?)\s*(?:ms|milliseconds?)\b", re.IGNORECASE),
+    re.compile(r"(\d+(?:\.\d+)?)\s*(?:s|seconds?)\b", re.IGNORECASE),
+]
+
+
+# === TYPES ===
+
+
+class Severity(StrEnum):
+    """Hang severity bucket. String-valued for stable JSON serialisation."""
+
+    MINOR = "minor"
+    WARN = "warn"
+    CRITICAL = "critical"
+    FROZEN = "frozen"
+
+
+_SEVERITY_WEIGHT = {
+    Severity.MINOR: 1,
+    Severity.WARN: 2,
+    Severity.CRITICAL: 4,
+    Severity.FROZEN: 8,
+}
+
+
+@dataclass
+class NormalisedEvent:
+    """A single hang event after parse + normalise + bucket."""
+
+    delta_ms: int
+    process: str
+    pid: int
+    duration_ms: float
+    severity: Severity
+    symbol: str | None
+    message_prefix: str
+    fingerprint: str
+    raw_message: str = ""
+
+
+@dataclass
+class Cluster:
+    """A group of NormalisedEvents sharing a fingerprint."""
+
+    fingerprint: str
+    count: int
+    max_duration_ms: float
+    total_duration_ms: float
+    first_delta_ms: int
+    severity: Severity
+    symbol_or_prefix: str
+    sample_event: NormalisedEvent
+    auto_sample: dict | None = None
+
+
+@dataclass
+class SessionSummary:
+    """End-state summary of a session. Persisted to summary.json."""
+
+    session_id: str
+    started_at: str
+    duration_ms: int
+    event_count: int
+    dropped_below_threshold: int
+    matched_lines: int
+    total_lines: int
+    clusters: list[Cluster]
+    aggregates: dict
+    fingerprint_version: int = FINGERPRINT_VERSION
+
+
+# === STAGE 1: PARSE ===
+
+
+def parse_log_line(line: str) -> dict | None:
+    """Parse one `xcrun simctl spawn log stream` line into a raw event dict.
+
+    Returns ``None`` for non-log lines or lines that don't describe a hang.
+    """
+    if not line.strip():
+        return None
+    match = _LOG_LINE_PATTERN.match(line)
+    if not match:
+        return None
+    timestamp_str, pid_str, process_name, message = match.groups()
+    message = message.strip()
+    if not is_hang_message(message):
+        return None
+    event: dict = {
+        "timestamp": timestamp_str.strip(),
+        "pid": int(pid_str),
+        "process": process_name.strip(),
+        "message": message,
+    }
+    duration_ms = extract_duration_ms(message)
+    if duration_ms is not None:
+        event["duration_ms"] = duration_ms
+    return event
+
+
+def is_hang_message(message: str) -> bool:
+    """Return True if message text describes a hang/stall/watchdog event."""
+    lower = message.lower()
+    return any(kw in lower for kw in ("hang", "stall", "unresponsive", "watchdog", "jetsam"))
+
+
+def extract_duration_ms(message: str) -> float | None:
+    """Parse hang duration from message text. Returns milliseconds."""
+    match = _DURATION_PATTERNS[0].search(message)
+    if match:
+        return float(match.group(1))
+    match = _DURATION_PATTERNS[1].search(message)
+    if match:
+        return float(match.group(1)) * 1000
+    return None
+
+
+# === STAGE 2: NORMALISE ===
+
+
+def normalise_message(message: str, max_len: int = 40) -> str:
+    """Strip boilerplate, redact volatile tokens, truncate to ``max_len``."""
+    text = message
+    for prefix in _BOILERPLATE_PREFIXES:
+        if text.startswith(prefix):
+            text = text[len(prefix) :].lstrip()
+            break
+    text = _HEX_ADDR.sub("<addr>", text)
+    text = _PID_REF.sub("<pid>", text)
+    text = _BARE_INT.sub("<n>", text)
+    text = _WHITESPACE.sub(" ", text).strip()
+    if len(text) > max_len:
+        text = text[:max_len].rstrip()
+    return text
+
+
+def extract_symbol(message: str) -> str | None:
+    """Return the first Obj-C / Swift symbol mention if present."""
+    for pattern in _SYMBOL_PATTERNS:
+        match = pattern.search(message)
+        if match:
+            return match.group(1)
+    return None
+
+
+# === STAGE 3: THRESHOLD ===
+
+
+def above_threshold(duration_ms: float | None, min_hang_ms: int) -> bool:
+    """Drop events with no duration or below the minimum hang threshold."""
+    return duration_ms is not None and duration_ms >= min_hang_ms
+
+
+# === STAGE 4: SEVERITY BUCKET ===
+
+
+def bucket_severity(duration_ms: float) -> Severity:
+    """Map ms to a severity band."""
+    if duration_ms < 250:
+        return Severity.MINOR
+    if duration_ms < 500:
+        return Severity.WARN
+    if duration_ms < 2000:
+        return Severity.CRITICAL
+    return Severity.FROZEN
+
+
+# === STAGE 5: NORMALISED EVENT + FINGERPRINT ===
+
+
+def build_normalised_event(
+    raw_event: dict, session_start_ms: int, current_ms: int | None = None
+) -> NormalisedEvent | None:
+    """Combine stages 2 + 4 + fingerprint into one ``NormalisedEvent``.
+
+    Returns ``None`` if duration is missing — threshold filtering should have
+    dropped these already, but we guard for safety.
+    """
+    duration = raw_event.get("duration_ms")
+    if duration is None:
+        return None
+    if current_ms is None:
+        current_ms = _timestamp_to_ms(raw_event.get("timestamp", ""))
+    delta_ms = max(0, current_ms - session_start_ms) if current_ms else 0
+    message = raw_event.get("message", "")
+    symbol = extract_symbol(message)
+    prefix = normalise_message(message)
+    fingerprint = compute_fingerprint(symbol, prefix)
+    return NormalisedEvent(
+        delta_ms=delta_ms,
+        process=raw_event.get("process", "unknown"),
+        pid=int(raw_event.get("pid", 0)),
+        duration_ms=float(duration),
+        severity=bucket_severity(float(duration)),
+        symbol=symbol,
+        message_prefix=prefix,
+        fingerprint=fingerprint,
+        raw_message=message,
+    )
+
+
+def compute_fingerprint(symbol: str | None, message_prefix: str) -> str:
+    """Stable identity hash for clustering and diff.
+
+    Symbol when present (high signal); otherwise normalised message prefix.
+    No hashing — readability beats compression here.
+    """
+    return f"sym:{symbol}" if symbol else f"msg:{message_prefix}"
+
+
+def _timestamp_to_ms(ts: str) -> int:
+    """Parse an os_log timestamp like '2026-05-22 14:30:52.123456-0800' to ms epoch."""
+    if not ts:
+        return 0
+    try:
+        # `%z` requires a colon-less offset, which is what os_log emits.
+        dt = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f%z")
+    except ValueError:
+        try:
+            dt = datetime.strptime(ts.split(".", maxsplit=1)[0], "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return 0
+    return int(dt.timestamp() * 1000)
+
+
+# === STAGE 6: CLUSTER ===
+
+
+def cluster_events(events: list[NormalisedEvent]) -> list[Cluster]:
+    """Group events by fingerprint, aggregating count + duration stats."""
+    by_fp: dict[str, list[NormalisedEvent]] = {}
+    for event in events:
+        by_fp.setdefault(event.fingerprint, []).append(event)
+    clusters: list[Cluster] = []
+    for fingerprint, group in by_fp.items():
+        durations = [e.duration_ms for e in group]
+        deltas = [e.delta_ms for e in group]
+        max_severity = max(group, key=lambda e: _SEVERITY_WEIGHT[e.severity]).severity
+        sample = max(group, key=lambda e: e.duration_ms)
+        clusters.append(
+            Cluster(
+                fingerprint=fingerprint,
+                count=len(group),
+                max_duration_ms=max(durations),
+                total_duration_ms=sum(durations),
+                first_delta_ms=min(deltas),
+                severity=max_severity,
+                symbol_or_prefix=sample.symbol or sample.message_prefix,
+                sample_event=sample,
+            )
+        )
+    return clusters
+
+
+# === STAGE 7: AGGREGATE ===
+
+
+def detect_temporal_bursts(
+    events: list[NormalisedEvent], window_ms: int = 1000, min_count: int = 3
+) -> list[dict]:
+    """Find windows containing ``min_count`` or more events within ``window_ms``."""
+    if not events:
+        return []
+    sorted_events = sorted(events, key=lambda e: e.delta_ms)
+    bursts: list[dict] = []
+    i = 0
+    while i < len(sorted_events):
+        window_start = sorted_events[i].delta_ms
+        j = i
+        while j < len(sorted_events) and sorted_events[j].delta_ms - window_start <= window_ms:
+            j += 1
+        burst_size = j - i
+        if burst_size >= min_count:
+            bursts.append(
+                {
+                    "starts_at_ms": window_start,
+                    "ends_at_ms": sorted_events[j - 1].delta_ms,
+                    "count": burst_size,
+                }
+            )
+            i = j
+        else:
+            i += 1
+    return bursts
+
+
+def detect_quiet_periods(events: list[NormalisedEvent], threshold_ms: int = 5000) -> list[dict]:
+    """Find gaps between adjacent events that exceed ``threshold_ms``."""
+    if len(events) < 2:
+        return []
+    sorted_events = sorted(events, key=lambda e: e.delta_ms)
+    periods: list[dict] = []
+    for prev, curr in itertools.pairwise(sorted_events):
+        gap = curr.delta_ms - prev.delta_ms
+        if gap >= threshold_ms:
+            periods.append({"from_ms": prev.delta_ms, "to_ms": curr.delta_ms, "gap_ms": gap})
+    return periods
+
+
+def process_distribution(events: list[NormalisedEvent]) -> dict[str, int]:
+    """Count events per process name."""
+    dist: dict[str, int] = {}
+    for event in events:
+        dist[event.process] = dist.get(event.process, 0) + 1
+    return dist
+
+
+# === STAGE 8: RANK ===
+
+
+def rank_clusters(clusters: list[Cluster], top_n: int | None = None) -> list[Cluster]:
+    """Sort by severity_weight * max_duration_ms * log(count + 1), descending."""
+
+    def score(cluster: Cluster) -> float:
+        weight = _SEVERITY_WEIGHT[cluster.severity]
+        return weight * cluster.max_duration_ms * math.log(cluster.count + 1)
+
+    ranked = sorted(clusters, key=score, reverse=True)
+    return ranked if top_n is None else ranked[:top_n]
+
+
+# === STAGE 9: FORMAT ===
+
+
+def format_l0(summary: SessionSummary) -> str:
+    """Single-line status (~20 tokens). Cache-friendly for agent context."""
+    if not summary.clusters:
+        return f"Session {summary.session_id}: no hangs above threshold."
+    top = summary.clusters[0]
+    critical = sum(
+        1 for c in summary.clusters if c.severity in (Severity.CRITICAL, Severity.FROZEN)
+    )
+    return (
+        f"Session {summary.session_id}: {summary.duration_ms / 1000:.1f}s, "
+        f"{summary.event_count} hangs ({critical} critical), top: "
+        f"{top.symbol_or_prefix} {top.max_duration_ms:.0f}ms ×{top.count}"
+    )
+
+
+def format_l1(summary: SessionSummary, top_n: int = 3) -> str:
+    """Default ~80-120 token output: header + top-N clusters + drill hint."""
+    if not summary.clusters:
+        return (
+            f"Session {summary.session_id}: {summary.duration_ms / 1000:.1f}s, "
+            f"no hangs ≥ threshold (scanned {summary.matched_lines}/{summary.total_lines} lines).\n"
+            f"Drill: hang_watcher.py --get-details {summary.session_id}"
+        )
+    lines = [
+        f"Session {summary.session_id}: {summary.duration_ms / 1000:.1f}s captured, "
+        f"{len(summary.clusters)} clusters ({summary.event_count} events)"
+    ]
+    icons = {
+        Severity.MINOR: "·",
+        Severity.WARN: "⚠",
+        Severity.CRITICAL: "⚠",
+        Severity.FROZEN: "🛑",
+    }
+    for cluster in summary.clusters[:top_n]:
+        icon = icons[cluster.severity]
+        at = f"{cluster.first_delta_ms / 1000:.1f}s"
+        lines.append(
+            f"{icon} {cluster.max_duration_ms:.0f}ms × {cluster.count} — "
+            f"{cluster.symbol_or_prefix} at {at}"
+        )
+    lines.append(f"Drill: hang_watcher.py --get-details {summary.session_id} [--cluster N]")
+    return "\n".join(lines)
+
+
+def format_l2(summary: SessionSummary) -> str:
+    """Expanded ~300 token output: all clusters + aggregates."""
+    parts = [format_l1(summary, top_n=len(summary.clusters))]
+    sev_hist = _severity_histogram(summary.clusters)
+    parts.append("Severity: " + ", ".join(f"{k}={v}" for k, v in sev_hist.items() if v))
+    aggregates = summary.aggregates or {}
+    bursts = aggregates.get("bursts", [])
+    if bursts:
+        burst_str = "; ".join(
+            f"{b['count']} in {(b['ends_at_ms'] - b['starts_at_ms'])}ms @ {b['starts_at_ms'] / 1000:.1f}s"
+            for b in bursts[:3]
+        )
+        parts.append(f"Bursts: {burst_str}")
+    quiet = aggregates.get("quiet_periods", [])
+    if quiet:
+        parts.append(f"Quiet periods: {len(quiet)} (longest {max(q['gap_ms'] for q in quiet)}ms)")
+    proc = aggregates.get("process_distribution", {})
+    if len(proc) > 1:
+        top_proc = sorted(proc.items(), key=lambda kv: kv[1], reverse=True)[:3]
+        parts.append("Processes: " + ", ".join(f"{p}({c})" for p, c in top_proc))
+    parts.append(
+        f"Lines: matched {summary.matched_lines}/{summary.total_lines}, "
+        f"dropped {summary.dropped_below_threshold} sub-threshold"
+    )
+    return "\n".join(parts)
+
+
+def format_cluster_detail(cluster: Cluster, events: list[NormalisedEvent]) -> str:
+    """L3: per-event detail for a single cluster, plus stack if sampled."""
+    lines = [
+        f"Cluster: {cluster.symbol_or_prefix}",
+        f"  fingerprint={cluster.fingerprint} severity={cluster.severity.value}",
+        f"  count={cluster.count} max={cluster.max_duration_ms:.0f}ms "
+        f"total={cluster.total_duration_ms:.0f}ms first@{cluster.first_delta_ms}ms",
+    ]
+    for event in events[:20]:
+        lines.append(
+            f"  · t={event.delta_ms}ms duration={event.duration_ms:.0f}ms "
+            f"process={event.process} pid={event.pid}"
+        )
+        if event.raw_message:
+            lines.append(f"      msg: {event.raw_message[:120]}")
+    if cluster.auto_sample:
+        stack = cluster.auto_sample.get("stack")
+        if stack:
+            lines.append("Auto-sample stack (top 10):")
+            lines.extend(f"  {frame}" for frame in stack[:10])
+        else:
+            lines.append(f"Auto-sample unavailable: {cluster.auto_sample.get('reason', 'unknown')}")
+    return "\n".join(lines)
+
+
+def format_diff(diff: dict) -> str:
+    """Render a diff_sessions() result for human + agent consumption."""
+    if diff.get("version_mismatch"):
+        return (
+            f"⚠ fingerprint_version mismatch: A={diff['fingerprint_version_a']} "
+            f"B={diff['fingerprint_version_b']}. Structural compare skipped."
+        )
+    new = diff.get("new_clusters", [])
+    resolved = diff.get("resolved_clusters", [])
+    drift = diff.get("drift", [])
+    stable = diff.get("stable_count", 0)
+    verdict = diff.get("verdict", "no change")
+    lines = [f"Diff {diff['session_a']} → {diff['session_b']}: {verdict}"]
+    if new:
+        lines.append(f"New ({len(new)}):")
+        for cluster in new[:5]:
+            lines.append(
+                f"  + {cluster['severity']} {cluster['max_duration_ms']:.0f}ms × "
+                f"{cluster['count']} — {cluster['symbol_or_prefix']}"
+            )
+    if resolved:
+        lines.append(f"Resolved ({len(resolved)}):")
+        for cluster in resolved[:5]:
+            lines.append(
+                f"  - {cluster['severity']} {cluster['max_duration_ms']:.0f}ms × "
+                f"{cluster['count']} — {cluster['symbol_or_prefix']}"
+            )
+    if drift:
+        lines.append(f"Drift ({len(drift)}):")
+        for entry in drift[:5]:
+            lines.append(
+                f"  ~ {entry['symbol_or_prefix']}: "
+                f"{entry['max_duration_ms_a']:.0f} → {entry['max_duration_ms_b']:.0f}ms "
+                f"({entry['delta_pct']:+.0f}%)"
+            )
+    if stable:
+        lines.append(f"Stable: {stable} cluster(s) unchanged")
+    return "\n".join(lines)
+
+
+def _severity_histogram(clusters: list[Cluster]) -> dict[str, int]:
+    """Total event count per severity band across clusters."""
+    hist = {s.value: 0 for s in Severity}
+    for cluster in clusters:
+        hist[cluster.severity.value] += cluster.count
+    return hist
+
+
+# === STAGE 10: TOKEN BUDGET ===
+
+
+def estimate_tokens(text: str) -> int:
+    """Documented char/4 heuristic. Real tokenizers differ ~10%; tests use this estimator."""
+    return len(text) // 4
+
+
+def compress_to_budget(
+    summary: SessionSummary, max_tokens: int | None, default_top_n: int = 3
+) -> str:
+    """Pick the densest level that fits ``max_tokens``.
+
+    Order: L2 (full) → L1 (top-N) → L0 (one-liner). When ``max_tokens`` is
+    ``None`` we return L1 unconditionally.
+    """
+    if max_tokens is None:
+        return format_l1(summary, top_n=default_top_n)
+    if max_tokens >= 200:
+        candidate = format_l2(summary)
+        if estimate_tokens(candidate) <= max_tokens:
+            return candidate
+    if max_tokens >= 60:
+        candidate = format_l1(summary, top_n=default_top_n)
+        if estimate_tokens(candidate) <= max_tokens:
+            return candidate
+        # Shrink top-N until it fits, never below 1.
+        for n in (2, 1):
+            candidate = format_l1(summary, top_n=n)
+            if estimate_tokens(candidate) <= max_tokens:
+                return candidate
+    return format_l0(summary)
+
+
+# === DIFF ===
+
+
+def diff_sessions(
+    summary_a: SessionSummary, summary_b: SessionSummary, drift_threshold_pct: float = 20.0
+) -> dict:
+    """Compare two SessionSummary instances. Returns a dict structured for format_diff."""
+    if summary_a.fingerprint_version != summary_b.fingerprint_version:
+        return {
+            "session_a": summary_a.session_id,
+            "session_b": summary_b.session_id,
+            "version_mismatch": True,
+            "fingerprint_version_a": summary_a.fingerprint_version,
+            "fingerprint_version_b": summary_b.fingerprint_version,
+            "verdict": "skipped (version mismatch)",
+        }
+    a_map = {c.fingerprint: c for c in summary_a.clusters}
+    b_map = {c.fingerprint: c for c in summary_b.clusters}
+    new_keys = b_map.keys() - a_map.keys()
+    resolved_keys = a_map.keys() - b_map.keys()
+    shared_keys = a_map.keys() & b_map.keys()
+    drift: list[dict] = []
+    stable = 0
+    for key in shared_keys:
+        ca, cb = a_map[key], b_map[key]
+        if ca.max_duration_ms == 0:
+            continue
+        delta_pct = (cb.max_duration_ms - ca.max_duration_ms) / ca.max_duration_ms * 100
+        if abs(delta_pct) >= drift_threshold_pct:
+            drift.append(
+                {
+                    "fingerprint": key,
+                    "symbol_or_prefix": cb.symbol_or_prefix,
+                    "max_duration_ms_a": ca.max_duration_ms,
+                    "max_duration_ms_b": cb.max_duration_ms,
+                    "delta_pct": delta_pct,
+                }
+            )
+        else:
+            stable += 1
+    new_clusters = [_cluster_to_dict(b_map[k]) for k in new_keys]
+    resolved_clusters = [_cluster_to_dict(a_map[k]) for k in resolved_keys]
+    new_critical = sum(
+        1 for c in new_clusters if c["severity"] in (Severity.CRITICAL.value, Severity.FROZEN.value)
+    )
+    if new_critical:
+        verdict = f"regression: {new_critical} new critical"
+    elif new_clusters:
+        verdict = f"regression: {len(new_clusters)} new minor"
+    elif resolved_clusters and not drift:
+        verdict = f"improvement: {len(resolved_clusters)} resolved"
+    elif drift:
+        worsened = sum(1 for d in drift if d["delta_pct"] > 0)
+        verdict = f"drift: {worsened} worsened, {len(drift) - worsened} improved"
+    else:
+        verdict = "no change"
+    return {
+        "session_a": summary_a.session_id,
+        "session_b": summary_b.session_id,
+        "version_mismatch": False,
+        "new_clusters": new_clusters,
+        "resolved_clusters": resolved_clusters,
+        "drift": drift,
+        "stable_count": stable,
+        "verdict": verdict,
+    }
+
+
+def _cluster_to_dict(cluster: Cluster) -> dict:
+    """Lightweight dict view for diff output (skips full sample_event for token economy)."""
+    return {
+        "fingerprint": cluster.fingerprint,
+        "symbol_or_prefix": cluster.symbol_or_prefix,
+        "severity": cluster.severity.value,
+        "count": cluster.count,
+        "max_duration_ms": cluster.max_duration_ms,
+        "first_delta_ms": cluster.first_delta_ms,
+    }
+
+
+# === SERIALISATION HELPERS ===
+
+
+def cluster_to_json(cluster: Cluster) -> dict:
+    """JSON-serialisable representation of a Cluster (handles enum + nested dataclass)."""
+    payload = asdict(cluster)
+    payload["severity"] = cluster.severity.value
+    payload["sample_event"]["severity"] = cluster.sample_event.severity.value
+    return payload
+
+
+def summary_to_json(summary: SessionSummary) -> dict:
+    """JSON-serialisable representation of a SessionSummary."""
+    return {
+        "session_id": summary.session_id,
+        "started_at": summary.started_at,
+        "duration_ms": summary.duration_ms,
+        "event_count": summary.event_count,
+        "dropped_below_threshold": summary.dropped_below_threshold,
+        "matched_lines": summary.matched_lines,
+        "total_lines": summary.total_lines,
+        "fingerprint_version": summary.fingerprint_version,
+        "clusters": [cluster_to_json(c) for c in summary.clusters],
+        "aggregates": summary.aggregates,
+    }
+
+
+def summary_from_json(payload: dict) -> SessionSummary:
+    """Rehydrate a SessionSummary from disk JSON."""
+    clusters = [_cluster_from_json(c) for c in payload.get("clusters", [])]
+    return SessionSummary(
+        session_id=payload["session_id"],
+        started_at=payload["started_at"],
+        duration_ms=payload["duration_ms"],
+        event_count=payload["event_count"],
+        dropped_below_threshold=payload.get("dropped_below_threshold", 0),
+        matched_lines=payload.get("matched_lines", 0),
+        total_lines=payload.get("total_lines", 0),
+        clusters=clusters,
+        aggregates=payload.get("aggregates", {}),
+        fingerprint_version=payload.get("fingerprint_version", 1),
+    )
+
+
+def _cluster_from_json(payload: dict) -> Cluster:
+    sample_payload = payload["sample_event"]
+    sample = NormalisedEvent(
+        delta_ms=sample_payload["delta_ms"],
+        process=sample_payload["process"],
+        pid=sample_payload["pid"],
+        duration_ms=sample_payload["duration_ms"],
+        severity=Severity(sample_payload["severity"]),
+        symbol=sample_payload.get("symbol"),
+        message_prefix=sample_payload["message_prefix"],
+        fingerprint=sample_payload["fingerprint"],
+        raw_message=sample_payload.get("raw_message", ""),
+    )
+    return Cluster(
+        fingerprint=payload["fingerprint"],
+        count=payload["count"],
+        max_duration_ms=payload["max_duration_ms"],
+        total_duration_ms=payload["total_duration_ms"],
+        first_delta_ms=payload["first_delta_ms"],
+        severity=Severity(payload["severity"]),
+        symbol_or_prefix=payload["symbol_or_prefix"],
+        sample_event=sample,
+        auto_sample=payload.get("auto_sample"),
+    )
+
+
+def event_to_jsonl(event: NormalisedEvent) -> str:
+    """Encode one normalised event as a single JSONL line."""
+    payload = asdict(event)
+    payload["severity"] = event.severity.value
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def event_from_jsonl(line: str) -> NormalisedEvent:
+    """Decode a single JSONL line back to NormalisedEvent."""
+    payload = json.loads(line)
+    return NormalisedEvent(
+        delta_ms=payload["delta_ms"],
+        process=payload["process"],
+        pid=payload["pid"],
+        duration_ms=payload["duration_ms"],
+        severity=Severity(payload["severity"]),
+        symbol=payload.get("symbol"),
+        message_prefix=payload["message_prefix"],
+        fingerprint=payload["fingerprint"],
+        raw_message=payload.get("raw_message", ""),
+    )
+
+
+# === BUILDERS ===
+
+
+@dataclass
+class SummaryBuilder:
+    """Compose clusters + aggregates into a SessionSummary in one place."""
+
+    session_id: str
+    started_at: str
+    duration_ms: int
+    matched_lines: int = 0
+    total_lines: int = 0
+    dropped_below_threshold: int = 0
+    extras: dict = field(default_factory=dict)
+
+    def build(self, events: list[NormalisedEvent], top_n: int | None = None) -> SessionSummary:
+        """Cluster, aggregate, rank, and emit a SessionSummary."""
+        clusters = rank_clusters(cluster_events(events), top_n=top_n)
+        aggregates = {
+            "bursts": detect_temporal_bursts(events),
+            "quiet_periods": detect_quiet_periods(events),
+            "process_distribution": process_distribution(events),
+        }
+        aggregates.update(self.extras)
+        return SessionSummary(
+            session_id=self.session_id,
+            started_at=self.started_at,
+            duration_ms=self.duration_ms,
+            event_count=len(events),
+            dropped_below_threshold=self.dropped_below_threshold,
+            matched_lines=self.matched_lines,
+            total_lines=self.total_lines,
+            clusters=clusters,
+            aggregates=aggregates,
+        )

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
@@ -410,7 +410,7 @@ def format_l1(summary: SessionSummary, top_n: int = 3) -> str:
     icons = {
         Severity.MINOR: "·",
         Severity.WARN: "⚠",
-        Severity.CRITICAL: "⚠",
+        Severity.CRITICAL: "‼",
         Severity.FROZEN: "🛑",
     }
     for cluster in summary.clusters[:top_n]:
@@ -643,10 +643,8 @@ def _cluster_to_dict(cluster: Cluster) -> dict:
 
 def cluster_to_json(cluster: Cluster) -> dict:
     """JSON-serialisable representation of a Cluster (handles enum + nested dataclass)."""
-    payload = asdict(cluster)
-    payload["severity"] = cluster.severity.value
-    payload["sample_event"]["severity"] = cluster.sample_event.severity.value
-    return payload
+    # asdict() already serialises Severity (StrEnum) members via their string value.
+    return asdict(cluster)
 
 
 def summary_to_json(summary: SessionSummary) -> dict:
@@ -710,9 +708,7 @@ def _cluster_from_json(payload: dict) -> Cluster:
 
 def event_to_jsonl(event: NormalisedEvent) -> str:
     """Encode one normalised event as a single JSONL line."""
-    payload = asdict(event)
-    payload["severity"] = event.severity.value
-    return json.dumps(payload, separators=(",", ":"))
+    return json.dumps(asdict(event), separators=(",", ":"))
 
 
 def event_from_jsonl(line: str) -> NormalisedEvent:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""HangBuster session storage — own dir layout, no ProgressiveCache reuse.
+
+Each session is a directory under ``~/.ios-simulator-skill/sessions/<id>/``
+containing ``meta.json`` (config + pid + status), ``events.jsonl``
+(append-only normalised events), and ``summary.json`` (post-stop).
+
+The parent creates the directory and writes initial meta. The detached
+worker updates meta with its own pid (avoids pidfile race) and appends to
+events.jsonl. ``--stop`` SIGTERMs the worker, drains events, builds a
+``SessionSummary``, and writes ``summary.json``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import secrets
+import signal
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from common.env_config import env_int
+from common.hang_pipeline import (
+    SessionSummary,
+    SummaryBuilder,
+    event_from_jsonl,
+    summary_from_json,
+    summary_to_json,
+)
+
+# === CONSTANTS ===
+
+DEFAULT_SESSIONS_DIR = Path("~/.ios-simulator-skill/sessions").expanduser()
+DEFAULT_TTL_HOURS = env_int("IOS_SIM_HANG_SESSION_TTL_HOURS", 24)
+
+_STATUS_PENDING = "pending"
+_STATUS_RUNNING = "running"
+_STATUS_STOPPED = "stopped"
+_STATUS_CRASHED = "crashed"
+
+_DURATION_RE = re.compile(r"(\d+)([smhd])$")
+
+
+# === TYPES ===
+
+
+@dataclass
+class SessionMeta:
+    """Parent + worker writes to meta.json."""
+
+    session_id: str
+    started_at: str
+    started_at_ms: int
+    args: dict
+    pid: int | None = None
+    status: str = _STATUS_PENDING
+    stopped_at: str | None = None
+    stopped_at_ms: int | None = None
+    extras: dict = field(default_factory=dict)
+
+    def to_json(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "started_at": self.started_at,
+            "started_at_ms": self.started_at_ms,
+            "args": self.args,
+            "pid": self.pid,
+            "status": self.status,
+            "stopped_at": self.stopped_at,
+            "stopped_at_ms": self.stopped_at_ms,
+            "extras": self.extras,
+        }
+
+    @classmethod
+    def from_json(cls, payload: dict) -> SessionMeta:
+        return cls(
+            session_id=payload["session_id"],
+            started_at=payload["started_at"],
+            started_at_ms=payload["started_at_ms"],
+            args=payload.get("args", {}),
+            pid=payload.get("pid"),
+            status=payload.get("status", _STATUS_PENDING),
+            stopped_at=payload.get("stopped_at"),
+            stopped_at_ms=payload.get("stopped_at_ms"),
+            extras=payload.get("extras", {}),
+        )
+
+
+# === SESSION STORE ===
+
+
+class SessionStore:
+    """Filesystem-backed session repository."""
+
+    def __init__(self, base_dir: Path | None = None):
+        self.base_dir = Path(base_dir).expanduser() if base_dir else DEFAULT_SESSIONS_DIR
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    # === PUBLIC API ===
+
+    def create(self, args: dict) -> SessionMeta:
+        """Generate id + dir + initial meta.json. Caller detaches the worker next."""
+        session_id = _generate_session_id()
+        session_dir = self.base_dir / session_id
+        session_dir.mkdir(parents=True, exist_ok=False)
+        # Empty events file so the worker can `open(..., 'a')` cleanly.
+        (session_dir / "events.jsonl").touch()
+        now = datetime.now()
+        meta = SessionMeta(
+            session_id=session_id,
+            started_at=now.isoformat(),
+            started_at_ms=int(now.timestamp() * 1000),
+            args=args,
+            status=_STATUS_PENDING,
+        )
+        self._write_meta(meta)
+        return meta
+
+    def wait_for_worker(self, session_id: str, timeout_seconds: float = 2.0) -> SessionMeta:
+        """Poll meta.json until status=running or timeout. Raises on timeout."""
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            meta = self.load_meta(session_id)
+            if meta.status == _STATUS_RUNNING and meta.pid:
+                return meta
+            time.sleep(0.05)
+        raise TimeoutError(f"Worker for {session_id} did not register within {timeout_seconds}s")
+
+    def claim_worker(self, session_id: str, pid: int) -> SessionMeta:
+        """Called by worker on startup. Writes pid + status=running into meta."""
+        meta = self.load_meta(session_id)
+        meta.pid = pid
+        meta.status = _STATUS_RUNNING
+        self._write_meta(meta)
+        return meta
+
+    def stop(self, session_id: str, summary: SessionSummary) -> SessionMeta:
+        """Mark session stopped and persist the computed summary."""
+        meta = self.load_meta(session_id)
+        meta.status = _STATUS_STOPPED
+        now = datetime.now()
+        meta.stopped_at = now.isoformat()
+        meta.stopped_at_ms = int(now.timestamp() * 1000)
+        self._write_meta(meta)
+        self._write_summary(session_id, summary)
+        return meta
+
+    def mark_crashed(self, session_id: str) -> None:
+        """Best-effort: tag a session whose worker exited without a summary."""
+        try:
+            meta = self.load_meta(session_id)
+        except FileNotFoundError:
+            return
+        meta.status = _STATUS_CRASHED
+        self._write_meta(meta)
+
+    def signal_worker(self, session_id: str, sig: int = signal.SIGTERM) -> bool:
+        """Send ``sig`` to the worker pid recorded in meta.json. Returns True if delivered."""
+        meta = self.load_meta(session_id)
+        if not meta.pid:
+            return False
+        try:
+            os.kill(meta.pid, sig)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return False
+
+    def load_meta(self, session_id: str) -> SessionMeta:
+        path = self._meta_path(session_id)
+        if not path.exists():
+            raise FileNotFoundError(f"No meta.json for session {session_id}")
+        with open(path) as handle:
+            return SessionMeta.from_json(json.load(handle))
+
+    def load_summary(self, session_id: str) -> SessionSummary | None:
+        path = self._summary_path(session_id)
+        if not path.exists():
+            return None
+        with open(path) as handle:
+            return summary_from_json(json.load(handle))
+
+    def read_events(self, session_id: str) -> list:
+        """Read all events.jsonl lines, returning NormalisedEvent instances.
+
+        Skips non-event sentinel lines (e.g. ``{"event": "stream_ended"}``).
+        """
+        path = self._events_path(session_id)
+        if not path.exists():
+            return []
+        events = []
+        with open(path) as handle:
+            for raw in handle:
+                line = raw.strip()
+                if not line:
+                    continue
+                if '"event"' in line and '"stream_ended"' in line:
+                    continue
+                try:
+                    events.append(event_from_jsonl(line))
+                except (json.JSONDecodeError, KeyError):
+                    continue
+        return events
+
+    def events_path(self, session_id: str) -> Path:
+        """Worker writes here. Public so the worker can open it line-buffered."""
+        return self._events_path(session_id)
+
+    def session_dir(self, session_id: str) -> Path:
+        return self.base_dir / session_id
+
+    def list_sessions(self) -> list[SessionMeta]:
+        """All non-expired session metas, newest first."""
+        metas: list[SessionMeta] = []
+        for entry in self.base_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                metas.append(self.load_meta(entry.name))
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+        metas.sort(key=lambda m: m.started_at_ms, reverse=True)
+        return metas
+
+    def clear(self, older_than: str | None = None) -> int:
+        """Delete session dirs. ``older_than`` is a duration string like ``24h``."""
+        cutoff_ms = _resolve_cutoff_ms(older_than) if older_than else None
+        deleted = 0
+        for entry in self.base_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                meta = self.load_meta(entry.name)
+            except (FileNotFoundError, json.JSONDecodeError):
+                _remove_tree(entry)
+                deleted += 1
+                continue
+            if cutoff_ms is None or meta.started_at_ms <= cutoff_ms:
+                _remove_tree(entry)
+                deleted += 1
+        return deleted
+
+    def prune_expired(self, ttl_hours: int | None = None) -> int:
+        """Remove sessions older than ttl. Called on every ``create``."""
+        ttl = ttl_hours if ttl_hours is not None else DEFAULT_TTL_HOURS
+        cutoff = int((datetime.now() - timedelta(hours=ttl)).timestamp() * 1000)
+        return self._clear_older_than_ms(cutoff)
+
+    # === SUMMARY HELPERS ===
+
+    def build_summary(
+        self,
+        session_id: str,
+        matched_lines: int = 0,
+        total_lines: int = 0,
+        dropped_below_threshold: int = 0,
+        extras: dict | None = None,
+        top_n: int | None = None,
+    ) -> SessionSummary:
+        """Convenience: read events.jsonl and run the pipeline through SummaryBuilder."""
+        meta = self.load_meta(session_id)
+        events = self.read_events(session_id)
+        now = datetime.now()
+        duration_ms = int(now.timestamp() * 1000) - meta.started_at_ms
+        builder = SummaryBuilder(
+            session_id=session_id,
+            started_at=meta.started_at,
+            duration_ms=max(0, duration_ms),
+            matched_lines=matched_lines,
+            total_lines=total_lines,
+            dropped_below_threshold=dropped_below_threshold,
+            extras=extras or {},
+        )
+        return builder.build(events, top_n=top_n)
+
+    # === PRIVATE ===
+
+    def _meta_path(self, session_id: str) -> Path:
+        return self.base_dir / session_id / "meta.json"
+
+    def _events_path(self, session_id: str) -> Path:
+        return self.base_dir / session_id / "events.jsonl"
+
+    def _summary_path(self, session_id: str) -> Path:
+        return self.base_dir / session_id / "summary.json"
+
+    def _write_meta(self, meta: SessionMeta) -> None:
+        path = self._meta_path(meta.session_id)
+        tmp = path.with_suffix(".json.tmp")
+        # Atomic write — concurrent reads (e.g. the parent polling) never see a half-file.
+        with open(tmp, "w") as handle:
+            json.dump(meta.to_json(), handle, indent=2)
+        tmp.replace(path)
+
+    def _write_summary(self, session_id: str, summary: SessionSummary) -> None:
+        path = self._summary_path(session_id)
+        tmp = path.with_suffix(".json.tmp")
+        with open(tmp, "w") as handle:
+            json.dump(summary_to_json(summary), handle, indent=2)
+        tmp.replace(path)
+
+    def _clear_older_than_ms(self, cutoff_ms: int) -> int:
+        deleted = 0
+        for entry in self.base_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                meta = self.load_meta(entry.name)
+            except (FileNotFoundError, json.JSONDecodeError):
+                _remove_tree(entry)
+                deleted += 1
+                continue
+            if meta.started_at_ms <= cutoff_ms:
+                _remove_tree(entry)
+                deleted += 1
+        return deleted
+
+
+# === MODULE-LEVEL HELPERS ===
+
+
+def _generate_session_id() -> str:
+    """``hang-YYYYMMDD-HHmmss-XXXX`` — random hex suffix avoids same-second collisions."""
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    suffix = secrets.token_hex(2)
+    return f"hang-{timestamp}-{suffix}"
+
+
+def _resolve_cutoff_ms(duration_str: str) -> int:
+    """Parse e.g. ``24h``, ``30m`` and return the epoch-ms threshold."""
+    match = _DURATION_RE.match(duration_str.strip().lower())
+    if not match:
+        raise ValueError(f"Invalid duration: {duration_str!r}. Use 30s/5m/24h/7d.")
+    value, unit = int(match.group(1)), match.group(2)
+    seconds = value * {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    cutoff = datetime.now() - timedelta(seconds=seconds)
+    return int(cutoff.timestamp() * 1000)
+
+
+def _remove_tree(path: Path) -> None:
+    """rm -rf path. Used for session-dir cleanup."""
+    for child in path.iterdir():
+        if child.is_dir():
+            _remove_tree(child)
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                child.unlink()
+    with contextlib.suppress(OSError):
+        path.rmdir()

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
@@ -139,6 +139,18 @@ class SessionStore:
         self._write_meta(meta)
         return meta
 
+    def persist_worker_counters(self, session_id: str, counters: dict) -> None:
+        """Worker calls this at shutdown to flush its line counters into meta.
+
+        Re-reads meta from disk so a concurrent ``stop()`` that already wrote
+        ``status=stopped`` is not clobbered back to ``running``.
+        """
+        meta = self.load_meta(session_id)
+        meta.extras["line_counters"] = counters
+        if meta.status != _STATUS_STOPPED:
+            meta.status = _STATUS_RUNNING
+        self._write_meta(meta)
+
     def stop(self, session_id: str, summary: SessionSummary) -> SessionMeta:
         """Mark session stopped and persist the computed summary."""
         meta = self.load_meta(session_id)
@@ -200,7 +212,12 @@ class SessionStore:
                 line = raw.strip()
                 if not line:
                     continue
-                if '"event"' in line and '"stream_ended"' in line:
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # Skip non-event sentinel lines (e.g. {"event": "stream_ended"}).
+                if payload.get("event") == "stream_ended":
                     continue
                 try:
                     events.append(event_from_jsonl(line))
@@ -294,8 +311,11 @@ class SessionStore:
         path = self._meta_path(meta.session_id)
         tmp = path.with_suffix(".json.tmp")
         # Atomic write — concurrent reads (e.g. the parent polling) never see a half-file.
+        # fsync before replace makes the new contents durable, not just atomically renamed.
         with open(tmp, "w") as handle:
             json.dump(meta.to_json(), handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
         tmp.replace(path)
 
     def _write_summary(self, session_id: str, summary: SessionSummary) -> None:
@@ -303,6 +323,8 @@ class SessionStore:
         tmp = path.with_suffix(".json.tmp")
         with open(tmp, "w") as handle:
             json.dump(summary_to_json(summary), handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
         tmp.replace(path)
 
     def _clear_older_than_ms(self, cutoff_ms: int) -> int:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -1,38 +1,38 @@
 #!/usr/bin/env python3
 """
-iOS Simulator Hang Watcher
+iOS Simulator Hang Watcher — featuring HangBuster session mode.
 
-Live os_log hang stream from iOS simulators. Parses hang events from Apple's
-RunningBoard subsystem and UIKit/SwiftUI thread-stall reports into structured
-records with timestamp, PID, process, and duration estimate.
+Two surfaces live in this file:
 
-Predicate covers:
-- Major hangs: com.apple.runningboard subsystem (process kills / watchdog)
-- Micro-hangs: SwiftUI / UIKit "Hang detected" messages
-- Tunable via env var: IOS_SIM_HANG_PREDICATE
+1. **HangWatcher** (legacy, --watch / --since) — passive os_log hang stream.
+   Backward-compatible with PR #75.
+2. **HangBuster** (new, --start / --stop / --get-details / --list-sessions /
+   --clear-sessions / --diff) — agent-native session recorder. Detaches a
+   worker, normalises and thresholds events on the fly, clusters at stop time,
+   emits a token-tight summary with progressive drill paths.
 
-Usage Examples:
-    # Watch for hangs for 60 seconds (default mode)
-    python scripts/hang_watcher.py --watch --duration 60
+The shared filter pipeline lives in ``common/hang_pipeline.py``; session
+storage in ``common/hang_sessions.py``.
 
-    # Watch a specific app
-    python scripts/hang_watcher.py --watch --bundle-id com.example.app
+Environment variables (all read by ``common.env_config.env_int``):
 
-    # Show hangs from the last 5 minutes as JSON
-    python scripts/hang_watcher.py --since 5m --json
-
-    # Override predicate
-    IOS_SIM_HANG_PREDICATE='subsystem == "com.apple.runningboard"' \\
-        python scripts/hang_watcher.py --watch --duration 30
+- ``IOS_SIM_HANG_PREDICATE``         Override the default log predicate
+- ``IOS_SIM_HANG_MIN_MS``            Min event duration kept (default 250)
+- ``IOS_SIM_HANG_SESSION_TTL_HOURS`` Session prune age (default 24)
+- ``IOS_SIM_HANG_DEFAULT_TOP_N``     Default top-N for ``--stop`` L1 (default 3)
+- ``IOS_SIM_HANG_BUDGET_TOKENS``     Optional default for ``--budget-tokens``
 """
 
 import argparse
+import contextlib
 import json
 import os
 import re
+import select
 import signal
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -43,6 +43,29 @@ if _script_dir not in sys.path:
 
 from common.cache_utils import ProgressiveCache  # noqa: E402
 from common.device_utils import resolve_device_identifier  # noqa: E402
+from common.env_config import env_int  # noqa: E402
+from common.hang_pipeline import (  # noqa: E402
+    build_normalised_event,
+    compress_to_budget,
+    diff_sessions,
+    event_to_jsonl,
+    format_cluster_detail,
+    format_diff,
+    format_l0,
+    format_l1,
+    format_l2,
+    summary_to_json,
+)
+from common.hang_pipeline import (  # noqa: E402
+    extract_duration_ms as _pipeline_extract_duration_ms,
+)
+from common.hang_pipeline import (  # noqa: E402
+    is_hang_message as _pipeline_is_hang_message,
+)
+from common.hang_pipeline import (  # noqa: E402
+    parse_log_line as _pipeline_parse_log_line,
+)
+from common.hang_sessions import SessionStore  # noqa: E402
 
 # === CONSTANTS ===
 
@@ -52,27 +75,6 @@ DEFAULT_HANG_PREDICATE = (
     '(subsystem == "com.apple.runningboard") '
     'OR (eventMessage CONTAINS "Hang detected") '
     'OR ((eventMessage CONTAINS[c] "main thread") AND (eventMessage CONTAINS[c] "hang"))'
-)
-
-# Patterns for parsing duration estimates from hang messages.
-# Matches: "2.5s", "250ms", "1.2 seconds", "800 milliseconds"
-_DURATION_PATTERNS = [
-    re.compile(r"(\d+(?:\.\d+)?)\s*s(?:econds?)?(?!\w)", re.IGNORECASE),
-    re.compile(r"(\d+(?:\.\d+)?)\s*ms(?:illiseconds?)?(?!\w)", re.IGNORECASE),
-]
-
-# os_log stream output columns:
-# 2024-01-15 10:23:45.123456-0800 0x1234 Default   0x0 1234 0 ProcessName: Message
-_LOG_LINE_PATTERN = re.compile(
-    r"^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d+(?:[+-]\d{4})?)"  # timestamp
-    r"\s+0x[\da-f]+"  # thread
-    r"\s+\S+"  # type
-    r"\s+0x[\da-f]+"  # activity
-    r"\s+(\d+)"  # PID
-    r"\s+\d+"  # TTL
-    r"\s+([^:]+):"  # process name
-    r"\s*(.*)",  # message
-    re.IGNORECASE,
 )
 
 
@@ -369,61 +371,25 @@ class HangWatcher:
         ]
 
     def _parse_line(self, line: str) -> dict | None:
-        """Parse a single os_log line into a hang event dict.
+        """Parse a log line into a hang event dict. Delegates to ``hang_pipeline``.
 
-        Returns None if the line doesn't match expected format or isn't hang-related.
+        The legacy event dict carried ``duration_estimate_ms``; we map the
+        pipeline's ``duration_ms`` field back onto that name for backward compat.
         """
-        if not line.strip():
+        event = _pipeline_parse_log_line(line)
+        if event is None:
             return None
-
-        match = _LOG_LINE_PATTERN.match(line)
-        if not match:
-            return None
-
-        timestamp_str, pid_str, process_name, message = match.groups()
-        message = message.strip()
-
-        # Only surface lines that look like hang events
-        if not self._is_hang_message(message):
-            return None
-
-        event: dict = {
-            "timestamp": timestamp_str.strip(),
-            "pid": int(pid_str),
-            "process": process_name.strip(),
-            "message": message,
-        }
-
-        duration_ms = self._extract_duration_ms(message)
-        if duration_ms is not None:
-            event["duration_estimate_ms"] = duration_ms
-
+        if "duration_ms" in event:
+            event["duration_estimate_ms"] = event.pop("duration_ms")
         return event
 
     def _is_hang_message(self, message: str) -> bool:
-        """Return True if the message content describes a hang event."""
-        lower = message.lower()
-        return (
-            "hang" in lower
-            or "stall" in lower
-            or "unresponsive" in lower
-            or "watchdog" in lower
-            or "jetsam" in lower
-        )
+        """Delegate to ``hang_pipeline.is_hang_message``."""
+        return _pipeline_is_hang_message(message)
 
     def _extract_duration_ms(self, message: str) -> float | None:
-        """Parse hang duration from message text, returning milliseconds."""
-        # Try seconds pattern first (e.g., "2.5s", "1.2 seconds")
-        match = _DURATION_PATTERNS[0].search(message)
-        if match:
-            return float(match.group(1)) * 1000
-
-        # Try milliseconds pattern (e.g., "250ms")
-        match = _DURATION_PATTERNS[1].search(message)
-        if match:
-            return float(match.group(1))
-
-        return None
+        """Delegate to ``hang_pipeline.extract_duration_ms``."""
+        return _pipeline_extract_duration_ms(message)
 
     def _matches_bundle(self, event: dict, bundle_id: str) -> bool:
         """Check if event process name matches the bundle ID."""
@@ -457,69 +423,531 @@ class HangWatcher:
         signal.signal(signal.SIGINT, handle_sigint)
 
 
+# === HANGBUSTER (session mode) ===
+
+
+def _resolve_predicate(predicate: str | None, bundle_id: str | None) -> str:
+    """Resolution chain: CLI override → env var → default. Bundle filter ANDed in if set."""
+    base = predicate or os.getenv("IOS_SIM_HANG_PREDICATE") or DEFAULT_HANG_PREDICATE
+    if bundle_id:
+        app_name = bundle_id.rsplit(".", maxsplit=1)[-1]
+        bundle_clause = f'(processImagePath CONTAINS "/{app_name}.app/" OR process == "{app_name}")'
+        base = f"({base}) AND {bundle_clause}"
+    return base
+
+
+class HangBuster:
+    """Session-mode façade.
+
+    Methods route to ``SessionStore`` + filter pipeline. The worker subprocess
+    re-enters this class via ``run_worker()``.
+    """
+
+    def __init__(self, store: SessionStore | None = None):
+        self.store = store or SessionStore()
+
+    # === PUBLIC API ===
+
+    def start(self, args: dict, udid: str | None) -> str:
+        """Create session, detach worker, return session_id once worker registers."""
+        self.store.prune_expired()
+        resolved_udid = self._resolve_udid(udid)
+        meta = self.store.create({**args, "udid": resolved_udid})
+        cmd = [
+            sys.executable,
+            __file__,
+            "--worker-session-id",
+            meta.session_id,
+        ]
+        # The detached worker survives parent exit. ``start_new_session=True``
+        # calls setsid() so the process group is independent of the controlling TTY.
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+        try:
+            self.store.wait_for_worker(meta.session_id, timeout_seconds=3.0)
+        except TimeoutError:
+            self.store.mark_crashed(meta.session_id)
+            raise RuntimeError(f"Worker did not register within 3s for {meta.session_id}") from None
+        return meta.session_id
+
+    def stop(
+        self,
+        session_id: str,
+        budget_tokens: int | None = None,
+        top_n: int | None = None,
+        terse: bool = False,
+        json_mode: bool = False,
+    ) -> str:
+        """Signal worker, drain, build summary, return formatted output."""
+        delivered = self.store.signal_worker(session_id, signal.SIGTERM)
+        if delivered:
+            # Give the worker up to 2s to flush + exit cleanly.
+            self._wait_for_worker_exit(session_id, timeout_seconds=2.0)
+        meta = self.store.load_meta(session_id)
+        line_counters = meta.extras.get("line_counters", {})
+        summary = self.store.build_summary(
+            session_id,
+            matched_lines=line_counters.get("matched", 0),
+            total_lines=line_counters.get("total", 0),
+            dropped_below_threshold=line_counters.get("dropped", 0),
+        )
+        # Apply default top_n at summary-write time — keeps ranked clusters bounded.
+        effective_top_n = top_n or env_int("IOS_SIM_HANG_DEFAULT_TOP_N", 3)
+        summary.clusters = summary.clusters[:effective_top_n] if not top_n else summary.clusters
+        self.store.stop(session_id, summary)
+        if json_mode:
+            return json.dumps(summary_to_json(summary), indent=2)
+        if terse:
+            return format_l0(summary)
+        budget = budget_tokens or env_int("IOS_SIM_HANG_BUDGET_TOKENS", 0) or None
+        return compress_to_budget(summary, max_tokens=budget, default_top_n=effective_top_n)
+
+    def get_details(
+        self,
+        session_id: str,
+        cluster: int | None = None,
+        raw: bool = False,
+        resample: bool = False,
+        json_mode: bool = False,
+    ) -> str:
+        """Drill into a stored session. ``cluster`` is 1-indexed for human use."""
+        summary = self.store.load_summary(session_id)
+        if summary is None:
+            return f"No summary for {session_id}. Run --stop first."
+        if raw:
+            return self._dump_raw_events(session_id)
+        if cluster is not None:
+            index = cluster - 1
+            if index < 0 or index >= len(summary.clusters):
+                return f"Cluster {cluster} out of range (1..{len(summary.clusters)})"
+            target = summary.clusters[index]
+            events = [
+                e for e in self.store.read_events(session_id) if e.fingerprint == target.fingerprint
+            ]
+            if resample:
+                target.auto_sample = _attempt_auto_sample(events[0].pid if events else 0)
+            if json_mode:
+                from common.hang_pipeline import cluster_to_json
+
+                return json.dumps(cluster_to_json(target), indent=2)
+            return format_cluster_detail(target, events)
+        if json_mode:
+            return json.dumps(summary_to_json(summary), indent=2)
+        return format_l2(summary)
+
+    def list_sessions(self, json_mode: bool = False) -> str:
+        metas = self.store.list_sessions()
+        if json_mode:
+            return json.dumps([m.to_json() for m in metas], indent=2)
+        if not metas:
+            return "No sessions stored."
+        lines = [f"Sessions: {len(metas)}"]
+        for meta in metas[:20]:
+            stopped = meta.stopped_at or "-"
+            lines.append(
+                f"  {meta.session_id}  {meta.status:8s}  started={meta.started_at}  stopped={stopped}"
+            )
+        if len(metas) > 20:
+            lines.append(f"  ... {len(metas) - 20} more")
+        return "\n".join(lines)
+
+    def clear_sessions(self, older_than: str | None = None, json_mode: bool = False) -> str:
+        deleted = self.store.clear(older_than=older_than)
+        if json_mode:
+            return json.dumps({"deleted": deleted, "older_than": older_than})
+        suffix = f" older than {older_than}" if older_than else ""
+        return f"Cleared {deleted} session(s){suffix}."
+
+    def diff(self, session_a: str, session_b: str, json_mode: bool = False) -> str:
+        summary_a = self.store.load_summary(session_a)
+        summary_b = self.store.load_summary(session_b)
+        if summary_a is None or summary_b is None:
+            missing = [s for s, x in [(session_a, summary_a), (session_b, summary_b)] if x is None]
+            return f"Missing summary.json for: {', '.join(missing)}"
+        result = diff_sessions(summary_a, summary_b)
+        if json_mode:
+            return json.dumps(result, indent=2)
+        return format_diff(result)
+
+    # === WORKER ===
+
+    def run_worker(self, session_id: str) -> int:
+        """Long-running worker entrypoint. Returns exit code.
+
+        Layout: claim meta → resolve predicate → open events.jsonl line-buffered
+        → spawn ``xcrun simctl spawn ... log stream`` → loop with select-based
+        readline timeout. SIGTERM flushes and exits cleanly.
+        """
+        meta = self.store.claim_worker(session_id, pid=os.getpid())
+        args = meta.args
+        min_hang_ms = int(args.get("min_hang_ms", env_int("IOS_SIM_HANG_MIN_MS", 250)))
+        bundle_id = args.get("bundle_id")
+        predicate_override = args.get("predicate")
+        auto_sample = bool(args.get("auto_sample", False))
+        udid = args["udid"]
+        predicate = _resolve_predicate(predicate_override, bundle_id)
+
+        events_path = self.store.events_path(session_id)
+        counters = {"total": 0, "matched": 0, "dropped": 0}
+        sampled_fingerprints: set[str] = set()
+        stop_flag = {"value": False}
+
+        def _on_sigterm(_signum, _frame):
+            stop_flag["value"] = True
+
+        signal.signal(signal.SIGTERM, _on_sigterm)
+        signal.signal(signal.SIGINT, _on_sigterm)
+
+        cmd = ["xcrun", "simctl", "spawn", udid, "log", "stream", "--predicate", predicate]
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+        except FileNotFoundError:
+            self.store.mark_crashed(session_id)
+            return 2
+
+        last_fsync = time.time()
+        last_event_at = time.time()
+        stream_silence_seconds = 30.0
+
+        with open(events_path, "a", buffering=1) as out_handle:
+            while not stop_flag["value"]:
+                if proc.stdout is None:
+                    break
+                ready, _, _ = select.select([proc.stdout], [], [], 0.25)
+                if not ready:
+                    # No data this tick — check for stream silence + writer fsync.
+                    if time.time() - last_event_at > stream_silence_seconds:
+                        out_handle.write(
+                            json.dumps({"event": "stream_ended", "at_ms": int(time.time() * 1000)})
+                            + "\n"
+                        )
+                        out_handle.flush()
+                        break
+                    if time.time() - last_fsync > 1.0:
+                        out_handle.flush()
+                        os.fsync(out_handle.fileno())
+                        last_fsync = time.time()
+                    continue
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                counters["total"] += 1
+                last_event_at = time.time()
+                raw_event = _pipeline_parse_log_line(line.rstrip())
+                if raw_event is None:
+                    continue
+                counters["matched"] += 1
+                duration = raw_event.get("duration_ms")
+                if duration is None or duration < min_hang_ms:
+                    counters["dropped"] += 1
+                    continue
+                normalised = build_normalised_event(
+                    raw_event,
+                    session_start_ms=meta.started_at_ms,
+                    current_ms=int(time.time() * 1000),
+                )
+                if normalised is None:
+                    continue
+                if auto_sample and normalised.fingerprint not in sampled_fingerprints:
+                    sampled_fingerprints.add(normalised.fingerprint)
+                    self._stash_auto_sample(
+                        session_id, normalised, _attempt_auto_sample(normalised.pid)
+                    )
+                out_handle.write(event_to_jsonl(normalised) + "\n")
+
+            # Drain on shutdown — flush any pending lines + cleanup subprocess.
+            out_handle.flush()
+            with contextlib.suppress(OSError):
+                os.fsync(out_handle.fileno())
+
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        meta.extras["line_counters"] = counters
+        meta.status = meta.status if meta.status == "stopped" else "running"
+        # Worker can't write status=stopped — parent's stop() handles that. But we
+        # do persist the counters so stop() can read them.
+        self.store._write_meta(meta)
+        return 0
+
+    # === PRIVATE ===
+
+    def _wait_for_worker_exit(self, session_id: str, timeout_seconds: float) -> None:
+        meta = self.store.load_meta(session_id)
+        if not meta.pid:
+            return
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            try:
+                os.kill(meta.pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.05)
+
+    def _dump_raw_events(self, session_id: str) -> str:
+        path = self.store.events_path(session_id)
+        if not path.exists():
+            return ""
+        with open(path) as handle:
+            return handle.read()
+
+    def _resolve_udid(self, udid: str | None) -> str:
+        identifier = udid or "booted"
+        try:
+            return resolve_device_identifier(identifier)
+        except RuntimeError as error:
+            raise RuntimeError(str(error)) from error
+
+    def _stash_auto_sample(self, session_id: str, normalised, sample: dict | None) -> None:
+        """Record an auto-sample side-channel for later cluster annotation."""
+        sample_path = self.store.session_dir(session_id) / "auto_samples.json"
+        existing = {}
+        if sample_path.exists():
+            try:
+                with open(sample_path) as handle:
+                    existing = json.load(handle)
+            except (OSError, json.JSONDecodeError):
+                existing = {}
+        existing[normalised.fingerprint] = sample
+        with open(sample_path, "w") as handle:
+            json.dump(existing, handle)
+
+
+def _attempt_auto_sample(pid: int) -> dict:
+    """Soft-import main_thread_sampler and capture a 2s stack sample.
+
+    Issue #62 is a soft dependency — graceful degrade with placeholder record
+    when the module isn't present.
+    """
+    try:
+        from main_thread_sampler import sample_pid  # type: ignore[import-not-found]
+    except ImportError:
+        print(
+            "warning: --auto-sample requested but main_thread_sampler unavailable",
+            file=sys.stderr,
+        )
+        return {"stack": None, "reason": "main_thread_sampler not available"}
+    if not pid:
+        return {"stack": None, "reason": "no pid available"}
+    try:
+        return {"stack": sample_pid(pid, duration_seconds=2), "reason": "ok"}
+    except Exception as error:
+        return {"stack": None, "reason": f"sample failed: {error}"}
+
+
 # === CLI ===
 
 
-def main():
-    """Main entry point."""
-    parser = argparse.ArgumentParser(
-        description="Watch for iOS simulator hang events via os_log",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  python scripts/hang_watcher.py --watch --duration 60
-  python scripts/hang_watcher.py --watch --bundle-id com.example.app
-  python scripts/hang_watcher.py --since 5m --json
-  python scripts/hang_watcher.py --watch --duration 30 --predicate '(subsystem == "com.apple.runningboard")'
+def _add_legacy_args(parser: argparse.ArgumentParser) -> argparse._MutuallyExclusiveGroup:
+    """Add the v1 --watch / --since flags plus the new HangBuster subcommands.
 
-Environment variables:
-  IOS_SIM_HANG_PREDICATE   Override the default log predicate (useful for narrowing/broadening scope)
-        """,
-    )
-
-    # Mode — mutually exclusive
+    All modes share the same parser so users can keep using v1 invocations
+    unchanged. Subcommands are mutually exclusive (mode_group).
+    """
     mode_group = parser.add_mutually_exclusive_group(required=True)
     mode_group.add_argument(
-        "--watch",
-        action="store_true",
-        help="Live stream mode (runs until --duration or Ctrl-C)",
+        "--watch", action="store_true", help="Legacy live stream (until --duration / Ctrl-C)"
     )
     mode_group.add_argument(
         "--since",
         metavar="DURATION",
-        help="Show historical hangs from the past N time units (e.g. 5m, 1h, 30s)",
+        help="Legacy historical query (e.g. 5m, 1h, 30s)",
     )
+    mode_group.add_argument(
+        "--start",
+        action="store_true",
+        help="Start a HangBuster session (detached worker, returns session ID)",
+    )
+    mode_group.add_argument(
+        "--stop", metavar="SESSION_ID", help="Stop a session and emit the summary"
+    )
+    mode_group.add_argument(
+        "--get-details",
+        metavar="SESSION_ID",
+        help="Drill into a stored session (combine with --cluster N or --raw)",
+    )
+    mode_group.add_argument(
+        "--list-sessions", action="store_true", help="List stored HangBuster sessions"
+    )
+    mode_group.add_argument("--clear-sessions", action="store_true", help="Delete stored sessions")
+    mode_group.add_argument(
+        "--diff", nargs=2, metavar=("SESSION_A", "SESSION_B"), help="Compare two sessions"
+    )
+    # Internal worker entry — hidden from --help. Detached child re-enters this script with it.
+    mode_group.add_argument("--worker-session-id", metavar="ID", help=argparse.SUPPRESS)
+    return mode_group
 
-    # Filters
-    parser.add_argument("--bundle-id", help="Filter events to a specific app bundle ID")
-    parser.add_argument(
-        "--predicate",
-        help="Override the default os_log predicate (also settable via IOS_SIM_HANG_PREDICATE)",
+
+def main():
+    """Main entry point — supports v1 + HangBuster modes from one parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Watch for iOS simulator hang events via os_log. "
+            "Use --watch/--since for the v1 stream, or --start/--stop for HangBuster session mode."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # HangBuster session mode (agent-friendly):
+  SID=$(python scripts/hang_watcher.py --start --min-hang-ms 200)
+  # ... interact with the simulator ...
+  python scripts/hang_watcher.py --stop $SID
+  python scripts/hang_watcher.py --get-details $SID --cluster 1
+  python scripts/hang_watcher.py --list-sessions
+  python scripts/hang_watcher.py --diff $SID_A $SID_B
+  python scripts/hang_watcher.py --clear-sessions --older-than 24h
+
+  # Legacy:
+  python scripts/hang_watcher.py --watch --duration 60
+  python scripts/hang_watcher.py --since 5m --json
+
+Environment variables:
+  IOS_SIM_HANG_PREDICATE         Override the default log predicate
+  IOS_SIM_HANG_MIN_MS            Min event duration kept (default 250)
+  IOS_SIM_HANG_SESSION_TTL_HOURS Session prune age (default 24)
+  IOS_SIM_HANG_DEFAULT_TOP_N     Default top-N for --stop (default 3)
+  IOS_SIM_HANG_BUDGET_TOKENS     Default token budget for --stop
+        """,
     )
+    _add_legacy_args(parser)
+
+    # Filters / target
+    parser.add_argument("--bundle-id", help="Filter to a specific app bundle ID")
+    parser.add_argument("--predicate", help="Override the default os_log predicate")
     parser.add_argument("--udid", help="Device UDID (uses booted simulator if omitted)")
 
-    # Watch options
+    # Legacy-only
     parser.add_argument(
-        "--duration",
-        type=int,
-        metavar="SECONDS",
-        help="Stop watching after N seconds (--watch mode only)",
+        "--duration", type=int, metavar="SECONDS", help="Stop after N seconds (--watch only)"
     )
 
-    # Output options
-    parser.add_argument("--json", action="store_true", help="Emit JSON lines per hang event")
-    parser.add_argument("--verbose", action="store_true", help="Include raw log lines")
+    # HangBuster knobs
+    parser.add_argument(
+        "--min-hang-ms",
+        type=int,
+        help="Drop events below this duration (default 250 / env IOS_SIM_HANG_MIN_MS)",
+    )
+    parser.add_argument(
+        "--auto-sample",
+        action="store_true",
+        help="On hang, capture a main-thread stack via main_thread_sampler (#62)",
+    )
+    parser.add_argument("--top", type=int, dest="top_n", help="Top-N clusters to retain in summary")
+    parser.add_argument(
+        "--all", action="store_true", dest="all_clusters", help="Keep all clusters (no top-N cap)"
+    )
+    parser.add_argument(
+        "--budget-tokens", type=int, help="Max tokens for --stop output (picks L0/L1/L2)"
+    )
+    parser.add_argument(
+        "--cluster", type=int, help="Cluster index (1-based) for --get-details drill"
+    )
+    parser.add_argument(
+        "--resample", action="store_true", help="With --get-details: force a fresh auto-sample"
+    )
+    parser.add_argument("--raw", action="store_true", help="With --get-details: dump events.jsonl")
+    parser.add_argument(
+        "--older-than", help="With --clear-sessions: delete sessions older than e.g. 24h"
+    )
+    parser.add_argument("--terse", action="store_true", help="--stop: force L0 one-line output")
+
+    # Output
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    parser.add_argument("--verbose", action="store_true", help="Include raw lines (legacy modes)")
 
     args = parser.parse_args()
 
+    # === HangBuster worker entry ===
+    if args.worker_session_id:
+        buster = HangBuster()
+        sys.exit(buster.run_worker(args.worker_session_id))
+
+    # === HangBuster session subcommands ===
+    if args.start:
+        buster = HangBuster()
+        start_args = {
+            "min_hang_ms": (
+                args.min_hang_ms
+                if args.min_hang_ms is not None
+                else env_int("IOS_SIM_HANG_MIN_MS", 250)
+            ),
+            "bundle_id": args.bundle_id,
+            "predicate": args.predicate,
+            "auto_sample": args.auto_sample,
+        }
+        try:
+            session_id = buster.start(start_args, udid=args.udid)
+        except RuntimeError as error:
+            print(f"Error: {error}", file=sys.stderr)
+            sys.exit(1)
+        print(session_id)
+        sys.exit(0)
+
+    if args.stop:
+        buster = HangBuster()
+        top_n = None if args.all_clusters else args.top_n
+        out = buster.stop(
+            args.stop,
+            budget_tokens=args.budget_tokens,
+            top_n=top_n,
+            terse=args.terse,
+            json_mode=args.json,
+        )
+        print(out)
+        sys.exit(0)
+
+    if args.get_details:
+        buster = HangBuster()
+        out = buster.get_details(
+            args.get_details,
+            cluster=args.cluster,
+            raw=args.raw,
+            resample=args.resample,
+            json_mode=args.json,
+        )
+        print(out)
+        sys.exit(0)
+
+    if args.list_sessions:
+        buster = HangBuster()
+        print(buster.list_sessions(json_mode=args.json))
+        sys.exit(0)
+
+    if args.clear_sessions:
+        buster = HangBuster()
+        print(buster.clear_sessions(older_than=args.older_than, json_mode=args.json))
+        sys.exit(0)
+
+    if args.diff:
+        buster = HangBuster()
+        print(buster.diff(args.diff[0], args.diff[1], json_mode=args.json))
+        sys.exit(0)
+
+    # === Legacy modes ===
     if args.since:
         try:
-            _compute_start_timestamp(args.since)  # validate before constructing watcher
-        except ValueError as e:
-            parser.error(str(e))
+            _compute_start_timestamp(args.since)
+        except ValueError as error:
+            parser.error(str(error))
 
     watcher = HangWatcher(udid=args.udid)
-
     if args.watch:
         success = watcher.watch(
             duration_seconds=args.duration,
@@ -536,19 +964,13 @@ Environment variables:
             verbose=args.verbose,
             json_mode=args.json,
         )
-
     if not success:
         sys.exit(1)
-
-    # Post-run summary (--since mode only — not in live --watch or --json)
     if not args.json and not args.watch:
         print(f"\n{watcher.get_summary()}")
-
-    # Save to cache if events were captured
     if watcher.hang_events:
         cache_id = watcher.save_to_cache()
         print(f"Archive saved: {cache_id}", file=sys.stderr)
-
     sys.exit(0)
 
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -144,7 +144,7 @@ class HangWatcher:
             True if stream ran without fatal errors.
         """
         resolved_udid = self._resolve_udid()
-        effective_predicate = self._resolve_predicate(predicate, bundle_id)
+        effective_predicate = _resolve_predicate(predicate, bundle_id)
         cmd = self._build_stream_cmd(resolved_udid, effective_predicate)
 
         if verbose or not json_mode:
@@ -240,7 +240,7 @@ class HangWatcher:
             True if command ran without fatal errors.
         """
         resolved_udid = self._resolve_udid()
-        effective_predicate = self._resolve_predicate(predicate, bundle_id)
+        effective_predicate = _resolve_predicate(predicate, bundle_id)
         start_timestamp = self._compute_start_timestamp(since_duration)
         cmd = self._build_show_cmd(resolved_udid, effective_predicate, start_timestamp)
 
@@ -321,26 +321,6 @@ class HangWatcher:
         except RuntimeError as error:
             print(f"Error: {error}", file=sys.stderr)
             sys.exit(1)
-
-    def _resolve_predicate(self, override: str | None, bundle_id: str | None) -> str:
-        """Return the active log predicate.
-
-        Priority: CLI --predicate > IOS_SIM_HANG_PREDICATE env var > DEFAULT.
-        Bundle ID is always ANDed in as a predicate clause when provided, regardless
-        of whether a custom predicate source is in use.
-        """
-        base = override or os.getenv("IOS_SIM_HANG_PREDICATE") or DEFAULT_HANG_PREDICATE
-
-        if bundle_id:
-            # Use /.app/ path segment for precise matching — avoids substring collisions
-            # (e.g. "Maps" matching "MapsExtension"). Falls back to process name.
-            app_name = bundle_id.rsplit(".", maxsplit=1)[-1]
-            bundle_clause = (
-                f'(processImagePath CONTAINS "/{app_name}.app/" OR process == "{app_name}")'
-            )
-            base = f"({base}) AND {bundle_clause}"
-
-        return base
 
     def _build_stream_cmd(self, udid: str, predicate: str) -> list[str]:
         """Build xcrun simctl spawn log stream command."""
@@ -499,7 +479,7 @@ class HangBuster:
         )
         # Apply default top_n at summary-write time — keeps ranked clusters bounded.
         effective_top_n = top_n or env_int("IOS_SIM_HANG_DEFAULT_TOP_N", 3)
-        summary.clusters = summary.clusters[:effective_top_n] if not top_n else summary.clusters
+        summary.clusters = summary.clusters[:effective_top_n]
         self.store.stop(session_id, summary)
         if json_mode:
             return json.dumps(summary_to_json(summary), indent=2)
@@ -680,11 +660,9 @@ class HangBuster:
             except subprocess.TimeoutExpired:
                 proc.kill()
 
-        meta.extras["line_counters"] = counters
-        meta.status = meta.status if meta.status == "stopped" else "running"
-        # Worker can't write status=stopped — parent's stop() handles that. But we
-        # do persist the counters so stop() can read them.
-        self.store._write_meta(meta)
+        # Flush line counters; SessionStore preserves status=stopped if the parent's
+        # stop() already raced ahead, otherwise marks status=running.
+        self.store.persist_worker_counters(session_id, counters)
         return 0
 
     # === PRIVATE ===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,8 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["xcode"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["ios-simulator-skill/skills/ios-simulator-skill/scripts"]
+addopts = "-ra"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ known-first-party = ["xcode"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["ios-simulator-skill/skills/ios-simulator-skill/scripts"]
+pythonpath = [".", "ios-simulator-skill/skills/ios-simulator-skill/scripts"]
 addopts = "-ra"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+"""Pytest bootstrap.
+
+`pythonpath` is configured in pyproject.toml so tests can `import common.*` and
+`import hang_pipeline` without sys.path mangling.
+"""

--- a/tests/fixtures/sample_session.py
+++ b/tests/fixtures/sample_session.py
@@ -1,0 +1,93 @@
+"""Builders for synthetic 30s / 50-event session data.
+
+Kept as code (not a static .jsonl) so the fixture stays in sync with any
+field-name changes in ``hang_pipeline``.
+"""
+
+from __future__ import annotations
+
+from common.hang_pipeline import (
+    NormalisedEvent,
+    SessionSummary,
+    Severity,
+    SummaryBuilder,
+    bucket_severity,
+    compute_fingerprint,
+)
+
+
+def make_events(count: int = 50, duration_window_ms: int = 30_000) -> list[NormalisedEvent]:
+    """Produce ``count`` synthetic events spread over ``duration_window_ms``.
+
+    Distribution: ~10 unique fingerprints, biased toward a few hot clusters so
+    output stays compact under the token-budget contract.
+    """
+    events: list[NormalisedEvent] = []
+    symbols = [
+        "[ImageDecoder decode:]",
+        "[NetworkSession fetch:]",
+        "MainViewModel.refresh()",
+        "[FileCache flush]",
+        "RunningBoard watchdog",
+        "[Layout calculateBounds]",
+        "[Database query:]",
+        "AnimationCoordinator.tick",
+        "[AudioEngine render]",
+        "[Notification post]",
+    ]
+    # Hot clusters: first 3 symbols get most of the volume.
+    hot_share = [22, 12, 8]  # 42 events across hot clusters
+    cold_share = [1] * (count - sum(hot_share))  # remaining spread across cold clusters
+    shares = hot_share + cold_share
+    delta_step = duration_window_ms // count
+    for i, share_idx in enumerate(_flatten_share(shares)):
+        symbol = symbols[share_idx % len(symbols)]
+        # Hot clusters get higher durations.
+        duration = 600 + (share_idx * 80) + (i % 5) * 20
+        events.append(
+            NormalisedEvent(
+                delta_ms=delta_step * i,
+                process="MyApp",
+                pid=4242,
+                duration_ms=duration,
+                severity=bucket_severity(duration),
+                symbol=symbol,
+                message_prefix=f"hang in {symbol}",
+                fingerprint=compute_fingerprint(symbol, f"hang in {symbol}"),
+                raw_message=f"Hang detected: {duration}ms in {symbol}",
+            )
+        )
+    return events
+
+
+def _flatten_share(shares: list[int]) -> list[int]:
+    """Convert per-bucket counts into a flat index list."""
+    return [idx for idx, count in enumerate(shares) for _ in range(count)]
+
+
+def make_summary(
+    event_count: int = 50,
+    session_id: str = "hang-20260522-143052-abcd",
+    top_n: int | None = None,
+    extras: dict | None = None,
+) -> SessionSummary:
+    """Run the pipeline against synthetic events and return a SessionSummary."""
+    events = make_events(event_count)
+    builder = SummaryBuilder(
+        session_id=session_id,
+        started_at="2026-05-22T14:30:52",
+        duration_ms=30_000,
+        matched_lines=event_count,
+        total_lines=event_count * 10,
+        dropped_below_threshold=event_count // 5,
+        extras=extras or {},
+    )
+    return builder.build(events, top_n=top_n)
+
+
+def assert_token_budget(text: str, max_tokens: int) -> None:
+    """Char/4 estimator — matches ``hang_pipeline.estimate_tokens`` exactly."""
+    actual = len(text) // 4
+    assert actual <= max_tokens, (
+        f"Token budget exceeded: {actual} > {max_tokens}\n--- output ---\n{text}"
+    )

--- a/tests/manual/hangbuster_smoke.sh
+++ b/tests/manual/hangbuster_smoke.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# HangBuster end-to-end smoke. Walks through every subcommand and verifies the
+# token-budget contract, legacy backward compat, and graceful behaviour when a
+# session has no hangs. Designed to be run by hand from the repo root.
+#
+# Usage:
+#   tests/manual/hangbuster_smoke.sh                  # uses booted simulator
+#   tests/manual/hangbuster_smoke.sh "iPhone 15"      # boots a specific device
+#   IOS_SIM_HANG_MIN_MS=100 tests/manual/hangbuster_smoke.sh
+#
+# What it checks:
+#   1. --help renders without error
+#   2. Empty session: --start → immediate --stop produces a clean "no hangs" line
+#   3. Real session: --start, 10s capture, --stop emits ~5-line L1 summary
+#   4. --get-details (L2) and --get-details --cluster 1 (L3) drill
+#   5. --budget-tokens 30 collapses to L0 one-line
+#   6. --json output parses
+#   7. --diff between two sessions emits a verdict line
+#   8. --list-sessions / --clear-sessions --older-than
+#   9. Legacy --watch --duration 3 still works
+
+set -euo pipefail
+
+SCRIPT="ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py"
+DEVICE="${1:-}"
+PASS=0
+FAIL=0
+
+if [[ ! -f "$SCRIPT" ]]; then
+  echo "error: run this from the repo root (couldn't find $SCRIPT)" >&2
+  exit 1
+fi
+
+# === HELPERS ===
+
+step() {
+  printf "\n\033[1;34m▸ %s\033[0m\n" "$*"
+}
+
+check() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf "  \033[1;32m✓\033[0m %s\n" "$label"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[1;31m✗\033[0m %s\n" "$label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf "  \033[1;32m✓\033[0m %s\n" "$label"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[1;31m✗\033[0m %s — expected substring %q\n     got: %s\n" \
+      "$label" "$needle" "$(printf '%s' "$haystack" | head -c 200)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_token_budget() {
+  local label="$1" budget="$2" text="$3"
+  local actual=$(( ${#text} / 4 ))
+  if (( actual <= budget )); then
+    printf "  \033[1;32m✓\033[0m %s (%d ≤ %d tokens)\n" "$label" "$actual" "$budget"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[1;31m✗\033[0m %s (%d > %d tokens)\n" "$label" "$actual" "$budget"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# === BOOT (if requested) ===
+
+step "Simulator preflight"
+if [[ -n "$DEVICE" ]]; then
+  echo "  Booting $DEVICE..."
+  xcrun simctl boot "$DEVICE" 2>/dev/null || true
+fi
+BOOTED=$(xcrun simctl list devices booted 2>/dev/null | grep -c Booted || true)
+if (( BOOTED == 0 )); then
+  echo "  ⚠ No simulator booted. Some checks will be skipped."
+  HAS_SIM=0
+else
+  echo "  ✓ Booted simulator(s): $BOOTED"
+  HAS_SIM=1
+fi
+
+# === 1. --help ===
+
+step "Help text"
+HELP=$(python "$SCRIPT" --help)
+assert_contains "Help mentions HangBuster session mode" "HangBuster session mode" "$HELP"
+assert_contains "Help lists --start" "--start" "$HELP"
+assert_contains "Help lists --diff" "--diff" "$HELP"
+assert_contains "Help lists --watch (legacy)" "Legacy live stream" "$HELP"
+assert_contains "Help documents env vars" "IOS_SIM_HANG_MIN_MS" "$HELP"
+
+# === 2. Empty session ===
+
+if (( HAS_SIM == 1 )); then
+  step "Empty session: --start → immediate --stop"
+  SID_EMPTY=$(python "$SCRIPT" --start --min-hang-ms 999999)  # threshold so high nothing matches
+  echo "  Session: $SID_EMPTY"
+  sleep 1
+  EMPTY_OUT=$(python "$SCRIPT" --stop "$SID_EMPTY")
+  echo "  Output:"
+  printf '%s\n' "$EMPTY_OUT" | sed 's/^/    /'
+  assert_contains "Empty session emits 'no hangs' line" "no hangs" "$EMPTY_OUT"
+  assert_token_budget "Empty L1 ≤ 200 tokens" 200 "$EMPTY_OUT"
+else
+  step "Empty session: SKIPPED (no booted simulator)"
+fi
+
+# === 3. Real session ===
+
+if (( HAS_SIM == 1 )); then
+  step "Real session: 10s capture"
+  SID=$(python "$SCRIPT" --start --min-hang-ms "${IOS_SIM_HANG_MIN_MS:-200}")
+  echo "  Session: $SID"
+  echo "  Interacting (sleep 10)... feel free to drive the simulator while this runs"
+  sleep 10
+  REAL_OUT=$(python "$SCRIPT" --stop "$SID")
+  echo "  Output:"
+  printf '%s\n' "$REAL_OUT" | sed 's/^/    /'
+  assert_contains "L1 references session ID" "$SID" "$REAL_OUT"
+  assert_contains "L1 includes drill hint" "Drill:" "$REAL_OUT"
+  assert_token_budget "Default L1 ≤ 200 tokens" 200 "$REAL_OUT"
+
+  # === 4. Drill ===
+  step "Drill: --get-details (L2)"
+  L2_OUT=$(python "$SCRIPT" --get-details "$SID")
+  assert_token_budget "L2 ≤ 2000 tokens" 2000 "$L2_OUT"
+  # Only sensible to drill into cluster 1 if there's at least one cluster.
+  if [[ "$REAL_OUT" != *"no hangs"* ]]; then
+    step "Drill: --get-details --cluster 1 (L3)"
+    L3_OUT=$(python "$SCRIPT" --get-details "$SID" --cluster 1)
+    assert_contains "L3 carries fingerprint=" "fingerprint=" "$L3_OUT"
+    assert_token_budget "L3 ≤ 2000 tokens" 2000 "$L3_OUT"
+  fi
+
+  # === 5. Budget collapse ===
+  step "Budget: --budget-tokens 30 collapses to L0"
+  L0_OUT=$(python "$SCRIPT" --stop "$SID" --budget-tokens 30 2>&1 || true)
+  # NOTE: --stop is idempotent re. running a second time after the worker exits;
+  # we re-call here just to exercise the formatter path with a tight budget.
+  # If the prior --stop wiped the session, generate a fresh empty one.
+  if [[ "$L0_OUT" == *"No meta.json"* ]]; then
+    SID2=$(python "$SCRIPT" --start --min-hang-ms 999999)
+    sleep 1
+    L0_OUT=$(python "$SCRIPT" --stop "$SID2" --budget-tokens 30)
+  fi
+  # L0 has no newline.
+  if [[ "$L0_OUT" != *$'\n'* ]]; then
+    printf "  \033[1;32m✓\033[0m L0 output is single-line\n"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[1;31m✗\033[0m L0 output should be single-line; got:\n%s\n" "$L0_OUT"
+    FAIL=$((FAIL + 1))
+  fi
+  assert_token_budget "L0 ≤ 30 tokens" 30 "$L0_OUT"
+
+  # === 6. JSON output ===
+  step "JSON: --get-details --json parses"
+  JSON_OUT=$(python "$SCRIPT" --get-details "$SID" --json)
+  if printf '%s' "$JSON_OUT" | python -c "import json,sys; json.loads(sys.stdin.read())"; then
+    printf "  \033[1;32m✓\033[0m JSON output parses\n"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[1;31m✗\033[0m JSON output did not parse\n"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  step "Real session / drill / budget / JSON: SKIPPED (no booted simulator)"
+fi
+
+# === 7. Diff ===
+
+if (( HAS_SIM == 1 )); then
+  step "Diff: two sessions"
+  SID_A=$(python "$SCRIPT" --start --min-hang-ms 999999)
+  sleep 1
+  python "$SCRIPT" --stop "$SID_A" >/dev/null
+  SID_B=$(python "$SCRIPT" --start --min-hang-ms 999999)
+  sleep 1
+  python "$SCRIPT" --stop "$SID_B" >/dev/null
+  DIFF_OUT=$(python "$SCRIPT" --diff "$SID_A" "$SID_B")
+  echo "  Output:"
+  printf '%s\n' "$DIFF_OUT" | sed 's/^/    /'
+  assert_contains "Diff references both sessions" "$SID_A" "$DIFF_OUT"
+  assert_contains "Diff references session B" "$SID_B" "$DIFF_OUT"
+  assert_contains "Diff includes verdict line" "no change" "$DIFF_OUT"
+else
+  step "Diff: SKIPPED (no booted simulator)"
+fi
+
+# === 8. List / clear ===
+
+step "List + clear"
+LIST_OUT=$(python "$SCRIPT" --list-sessions)
+echo "  --list-sessions:"
+printf '%s\n' "$LIST_OUT" | sed 's/^/    /' | head -10
+CLEAR_OUT=$(python "$SCRIPT" --clear-sessions --older-than 0s --json)
+assert_contains "--clear-sessions reports JSON" "deleted" "$CLEAR_OUT"
+
+# === 9. Legacy backward compat ===
+
+if (( HAS_SIM == 1 )); then
+  step "Legacy: --watch --duration 3"
+  # --watch exits after duration; we just need it to run + exit 0.
+  if python "$SCRIPT" --watch --duration 3 >/dev/null 2>&1; then
+    printf "  \033[1;32m✓\033[0m Legacy --watch exits cleanly\n"
+    PASS=$((PASS + 1))
+  else
+    printf "  \033[1;31m✗\033[0m Legacy --watch crashed\n"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  step "Legacy --watch: SKIPPED (no booted simulator)"
+fi
+
+# === SUMMARY ===
+
+step "Summary"
+printf "  Passed: %d\n  Failed: %d\n" "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+echo "  All checks passed."

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,133 @@
+"""Diff intelligence: regressions, improvements, drift, version mismatch."""
+
+from __future__ import annotations
+
+from common.hang_pipeline import (
+    SummaryBuilder,
+    bucket_severity,
+    compute_fingerprint,
+    diff_sessions,
+    format_diff,
+)
+from tests.fixtures.sample_session import make_events, make_summary
+
+
+# === diff_sessions ===
+
+
+def test_diff_no_change_when_identical():
+    a = make_summary(session_id="hang-a")
+    b = make_summary(session_id="hang-b")
+    result = diff_sessions(a, b)
+    assert result["verdict"] == "no change"
+    assert not result["new_clusters"]
+    assert not result["resolved_clusters"]
+
+
+def test_diff_detects_new_critical_cluster():
+    a = make_summary(session_id="hang-a")
+    b_events = make_events()
+    # Add a new high-severity event with a fresh fingerprint.
+    from common.hang_pipeline import NormalisedEvent
+
+    b_events.append(
+        NormalisedEvent(
+            delta_ms=29_000,
+            process="MyApp",
+            pid=42,
+            duration_ms=1800,
+            severity=bucket_severity(1800),
+            symbol="[BrandNew explode:]",
+            message_prefix="brand-new hang",
+            fingerprint=compute_fingerprint("[BrandNew explode:]", "brand-new hang"),
+        )
+    )
+    b = SummaryBuilder(
+        session_id="hang-b",
+        started_at="2026-05-22T14:35:00",
+        duration_ms=30_000,
+    ).build(b_events)
+    result = diff_sessions(a, b)
+    assert any(
+        "[BrandNew explode:]" == c["symbol_or_prefix"] for c in result["new_clusters"]
+    )
+    assert "regression" in result["verdict"]
+    assert "critical" in result["verdict"]
+
+
+def test_diff_detects_resolved_cluster():
+    a = make_summary(session_id="hang-a")
+    # B has fewer fingerprints than A — at least one resolved.
+    b_events = [
+        e for e in make_events() if e.symbol != "[ImageDecoder decode:]"
+    ]
+    b = SummaryBuilder(
+        session_id="hang-b",
+        started_at="2026-05-22T14:35:00",
+        duration_ms=30_000,
+    ).build(b_events)
+    result = diff_sessions(a, b)
+    assert any(
+        c["symbol_or_prefix"] == "[ImageDecoder decode:]" for c in result["resolved_clusters"]
+    )
+
+
+def test_diff_flags_drift_when_max_duration_grows():
+    a_events = make_events()
+    a = SummaryBuilder(
+        session_id="hang-a", started_at="t", duration_ms=30_000
+    ).build(a_events)
+    # B with the same fingerprints but 40% longer durations.
+    from common.hang_pipeline import NormalisedEvent
+
+    b_events = [
+        NormalisedEvent(
+            delta_ms=e.delta_ms,
+            process=e.process,
+            pid=e.pid,
+            duration_ms=e.duration_ms * 1.4,
+            severity=bucket_severity(e.duration_ms * 1.4),
+            symbol=e.symbol,
+            message_prefix=e.message_prefix,
+            fingerprint=e.fingerprint,
+        )
+        for e in a_events
+    ]
+    b = SummaryBuilder(
+        session_id="hang-b", started_at="t", duration_ms=30_000
+    ).build(b_events)
+    result = diff_sessions(a, b)
+    assert len(result["drift"]) > 0
+    # 40% bump should flag as worsened, not improved.
+    assert all(d["delta_pct"] > 0 for d in result["drift"])
+
+
+def test_diff_version_mismatch_skips_structural():
+    a = make_summary(session_id="hang-a")
+    b = make_summary(session_id="hang-b")
+    b.fingerprint_version = 99
+    result = diff_sessions(a, b)
+    assert result["version_mismatch"] is True
+    assert "skipped" in result["verdict"]
+    # No structural keys when mismatched.
+    assert "new_clusters" not in result or not result.get("new_clusters")
+
+
+# === format_diff ===
+
+
+def test_format_diff_no_change():
+    a = make_summary(session_id="hang-a")
+    b = make_summary(session_id="hang-b")
+    out = format_diff(diff_sessions(a, b))
+    assert "no change" in out
+    assert "hang-a" in out
+    assert "hang-b" in out
+
+
+def test_format_diff_version_mismatch_carries_warning():
+    a = make_summary(session_id="hang-a")
+    b = make_summary(session_id="hang-b")
+    b.fingerprint_version = 99
+    out = format_diff(diff_sessions(a, b))
+    assert "mismatch" in out.lower()

--- a/tests/test_hang_pipeline.py
+++ b/tests/test_hang_pipeline.py
@@ -1,0 +1,457 @@
+"""Per-stage unit tests for common.hang_pipeline."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from common.hang_pipeline import (
+    FINGERPRINT_VERSION,
+    Cluster,
+    NormalisedEvent,
+    SessionSummary,
+    Severity,
+    SummaryBuilder,
+    above_threshold,
+    bucket_severity,
+    build_normalised_event,
+    cluster_events,
+    compress_to_budget,
+    compute_fingerprint,
+    detect_quiet_periods,
+    detect_temporal_bursts,
+    diff_sessions,
+    estimate_tokens,
+    event_from_jsonl,
+    event_to_jsonl,
+    extract_duration_ms,
+    extract_symbol,
+    format_cluster_detail,
+    format_diff,
+    format_l0,
+    format_l1,
+    format_l2,
+    is_hang_message,
+    normalise_message,
+    parse_log_line,
+    process_distribution,
+    rank_clusters,
+    summary_from_json,
+    summary_to_json,
+)
+
+
+# === parse ===
+
+
+def test_parse_log_line_extracts_hang_event():
+    line = (
+        "2026-05-22 14:30:52.123456-0800 0x1234 Default   0x0 1234 0 "
+        "MyApp: Hang detected by RunningBoard: 487ms"
+    )
+    event = parse_log_line(line)
+    assert event is not None
+    assert event["process"] == "MyApp"
+    assert event["pid"] == 1234
+    assert event["duration_ms"] == 487
+
+
+def test_parse_log_line_returns_none_for_non_hang():
+    line = (
+        "2026-05-22 14:30:52.123456-0800 0x1234 Default   0x0 1234 0 "
+        "MyApp: just a regular log line"
+    )
+    assert parse_log_line(line) is None
+
+
+def test_parse_log_line_returns_none_for_garbage():
+    assert parse_log_line("") is None
+    assert parse_log_line("not a log line at all") is None
+
+
+def test_is_hang_message_matches_keywords():
+    assert is_hang_message("Hang detected")
+    assert is_hang_message("Main thread stall")
+    assert is_hang_message("App unresponsive")
+    assert is_hang_message("RunningBoard watchdog tripped")
+    assert is_hang_message("jetsam killed it")
+    assert not is_hang_message("everything is fine")
+
+
+def test_extract_duration_ms_seconds():
+    assert extract_duration_ms("Hang for 2.5s") == 2500.0
+    assert extract_duration_ms("stalled 1.2 seconds") == 1200.0
+
+
+def test_extract_duration_ms_milliseconds():
+    assert extract_duration_ms("Hang for 487ms") == 487.0
+    assert extract_duration_ms("250 milliseconds late") == 250.0
+
+
+def test_extract_duration_ms_none():
+    assert extract_duration_ms("no duration here") is None
+
+
+# === normalise ===
+
+
+def test_normalise_strips_boilerplate_and_redacts():
+    msg = "Hang detected by RunningBoard: pid:1234 at 0xdeadbeef for 487ms"
+    out = normalise_message(msg)
+    assert "Hang detected by RunningBoard" not in out
+    assert "0xdead" not in out
+    assert "1234" not in out
+    assert out.startswith("<pid>") or "<addr>" in out
+
+
+def test_normalise_truncates():
+    msg = "Hang " + "x" * 200
+    out = normalise_message(msg, max_len=20)
+    assert len(out) <= 20
+
+
+def test_normalise_collapses_whitespace():
+    out = normalise_message("Hang   detected\n\tat\tmain")
+    assert "  " not in out
+    assert "\n" not in out
+
+
+def test_extract_symbol_objc():
+    assert extract_symbol("crashed at [ImageDecoder decode:]") == "[ImageDecoder decode:]"
+
+
+def test_extract_symbol_swift():
+    sym = extract_symbol("Hang in MyClass.runWork() on main thread")
+    assert sym is not None and "MyClass.runWork" in sym
+
+
+def test_extract_symbol_none():
+    assert extract_symbol("just text no symbols") is None
+
+
+# === threshold ===
+
+
+def test_above_threshold_filters_correctly():
+    assert above_threshold(500.0, 250)
+    assert above_threshold(250.0, 250)
+    assert not above_threshold(100.0, 250)
+    assert not above_threshold(None, 250)
+
+
+# === severity ===
+
+
+@pytest.mark.parametrize(
+    "ms,expected",
+    [
+        (0, Severity.MINOR),
+        (100, Severity.MINOR),
+        (249, Severity.MINOR),
+        (250, Severity.WARN),
+        (400, Severity.WARN),
+        (499, Severity.WARN),
+        (500, Severity.CRITICAL),
+        (1500, Severity.CRITICAL),
+        (1999, Severity.CRITICAL),
+        (2000, Severity.FROZEN),
+        (5000, Severity.FROZEN),
+    ],
+)
+def test_bucket_severity_boundaries(ms, expected):
+    assert bucket_severity(ms) == expected
+
+
+# === fingerprint ===
+
+
+def test_compute_fingerprint_prefers_symbol():
+    fp = compute_fingerprint("[ImageDecoder decode:]", "fallback prefix")
+    assert fp.startswith("sym:")
+    assert "ImageDecoder" in fp
+
+
+def test_compute_fingerprint_falls_back_to_prefix():
+    fp = compute_fingerprint(None, "fallback prefix")
+    assert fp.startswith("msg:")
+    assert "fallback prefix" in fp
+
+
+# === build_normalised_event ===
+
+
+def test_build_normalised_event_full():
+    raw = {
+        "timestamp": "2026-05-22 14:30:52.000000-0800",
+        "pid": 1234,
+        "process": "MyApp",
+        "message": "Hang detected by RunningBoard: 487ms at [ImageDecoder decode:]",
+        "duration_ms": 487.0,
+    }
+    event = build_normalised_event(raw, session_start_ms=0, current_ms=12_400)
+    assert event is not None
+    assert event.duration_ms == 487.0
+    assert event.severity == Severity.WARN
+    assert event.symbol == "[ImageDecoder decode:]"
+    assert event.delta_ms == 12_400
+    assert event.fingerprint.startswith("sym:")
+
+
+def test_build_normalised_event_returns_none_without_duration():
+    raw = {"timestamp": "", "pid": 0, "process": "X", "message": "Hang somewhere"}
+    assert build_normalised_event(raw, session_start_ms=0) is None
+
+
+# === cluster ===
+
+
+def _event(fp_symbol: str, duration: float, delta: int = 1000, process: str = "MyApp") -> NormalisedEvent:
+    return NormalisedEvent(
+        delta_ms=delta,
+        process=process,
+        pid=1,
+        duration_ms=duration,
+        severity=bucket_severity(duration),
+        symbol=fp_symbol,
+        message_prefix="prefix",
+        fingerprint=compute_fingerprint(fp_symbol, "prefix"),
+    )
+
+
+def test_cluster_groups_by_fingerprint():
+    events = [
+        _event("[A foo]", 300),
+        _event("[A foo]", 500),
+        _event("[B bar]", 100),
+    ]
+    clusters = cluster_events(events)
+    assert len(clusters) == 2
+    by_fp = {c.fingerprint: c for c in clusters}
+    a_cluster = by_fp[compute_fingerprint("[A foo]", "prefix")]
+    assert a_cluster.count == 2
+    assert a_cluster.max_duration_ms == 500
+    assert a_cluster.severity == Severity.CRITICAL
+
+
+def test_cluster_picks_max_severity():
+    events = [_event("[A foo]", 100), _event("[A foo]", 3000)]
+    cluster = cluster_events(events)[0]
+    assert cluster.severity == Severity.FROZEN
+
+
+# === aggregators ===
+
+
+def test_detect_temporal_bursts():
+    events = [
+        _event("[X]", 300, delta=100),
+        _event("[X]", 300, delta=300),
+        _event("[X]", 300, delta=800),
+        _event("[X]", 300, delta=10_000),
+    ]
+    bursts = detect_temporal_bursts(events, window_ms=1000, min_count=3)
+    assert len(bursts) == 1
+    assert bursts[0]["count"] == 3
+
+
+def test_detect_quiet_periods():
+    events = [
+        _event("[X]", 300, delta=0),
+        _event("[X]", 300, delta=8000),
+        _event("[X]", 300, delta=9000),
+    ]
+    quiet = detect_quiet_periods(events, threshold_ms=5000)
+    assert len(quiet) == 1
+    assert quiet[0]["gap_ms"] == 8000
+
+
+def test_process_distribution():
+    events = [
+        _event("[X]", 300, process="A"),
+        _event("[X]", 300, process="A"),
+        _event("[X]", 300, process="B"),
+    ]
+    dist = process_distribution(events)
+    assert dist == {"A": 2, "B": 1}
+
+
+# === rank ===
+
+
+def test_rank_orders_by_severity_then_duration():
+    minor = _event("[m]", 100)
+    critical = _event("[c]", 600)
+    frozen = _event("[f]", 3000)
+    clusters = cluster_events([minor, critical, frozen])
+    ranked = rank_clusters(clusters)
+    assert ranked[0].severity == Severity.FROZEN
+    assert ranked[-1].severity == Severity.MINOR
+
+
+def test_rank_top_n():
+    events = [_event(f"[c{i}]", 500) for i in range(5)]
+    clusters = cluster_events(events)
+    assert len(rank_clusters(clusters, top_n=2)) == 2
+
+
+# === formatters ===
+
+
+def _build_summary(event_count: int = 10) -> SessionSummary:
+    events = [_event(f"[c{i % 3}]", 400 + i * 10, delta=i * 1000) for i in range(event_count)]
+    builder = SummaryBuilder(
+        session_id="hang-20260522-143052-abcd",
+        started_at="2026-05-22T14:30:52",
+        duration_ms=30_000,
+        matched_lines=event_count,
+        total_lines=event_count * 10,
+        dropped_below_threshold=2,
+    )
+    return builder.build(events)
+
+
+def test_format_l0_one_line():
+    summary = _build_summary()
+    out = format_l0(summary)
+    assert "\n" not in out
+    assert summary.session_id in out
+
+
+def test_format_l1_default_shape():
+    summary = _build_summary()
+    out = format_l1(summary)
+    lines = out.split("\n")
+    # 1 header + 3 clusters + 1 drill hint
+    assert len(lines) == 5
+    assert lines[-1].startswith("Drill:")
+
+
+def test_format_l1_empty_session():
+    builder = SummaryBuilder(
+        session_id="hang-empty",
+        started_at="2026-05-22T14:30:52",
+        duration_ms=5000,
+        matched_lines=0,
+        total_lines=100,
+    )
+    summary = builder.build([])
+    out = format_l1(summary)
+    assert "no hangs" in out.lower()
+
+
+def test_format_l2_includes_aggregates():
+    summary = _build_summary(event_count=20)
+    out = format_l2(summary)
+    assert "Severity:" in out
+    assert "Lines:" in out
+
+
+def test_format_cluster_detail():
+    summary = _build_summary()
+    cluster = summary.clusters[0]
+    events = [
+        e
+        for e in [
+            _event(cluster.sample_event.symbol or "[c0]", cluster.max_duration_ms, delta=i * 100)
+            for i in range(5)
+        ]
+    ]
+    out = format_cluster_detail(cluster, events)
+    assert "fingerprint=" in out
+    assert "severity=" in out
+
+
+# === token budget ===
+
+
+def test_estimate_tokens_is_char_div_4():
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("abcd") == 1
+    assert estimate_tokens("a" * 400) == 100
+
+
+def test_compress_to_budget_picks_l1_at_default():
+    summary = _build_summary()
+    out = compress_to_budget(summary, max_tokens=None)
+    assert "Drill:" in out
+
+
+def test_compress_to_budget_falls_back_to_l0_at_tight_budget():
+    summary = _build_summary(event_count=20)
+    out = compress_to_budget(summary, max_tokens=10)
+    assert "\n" not in out
+
+
+def test_compress_to_budget_uses_l2_at_high_budget():
+    summary = _build_summary(event_count=20)
+    out = compress_to_budget(summary, max_tokens=2000)
+    assert "Severity:" in out
+
+
+# === diff ===
+
+
+def test_diff_detects_new_critical():
+    a = _build_summary(event_count=5)
+    b_events = [
+        _event(f"[c{i % 3}]", 400 + i * 10, delta=i * 1000) for i in range(5)
+    ] + [_event("[new-critical]", 1500, delta=20_000)]
+    b = SummaryBuilder(
+        session_id="hang-b",
+        started_at="2026-05-22T14:31:00",
+        duration_ms=30_000,
+    ).build(b_events)
+    out = diff_sessions(a, b)
+    assert not out["version_mismatch"]
+    assert any("new-critical" in c["symbol_or_prefix"] for c in out["new_clusters"])
+    assert "regression" in out["verdict"]
+
+
+def test_diff_version_mismatch_skips_structural_compare():
+    a = _build_summary()
+    b = _build_summary()
+    b.fingerprint_version = 99
+    out = diff_sessions(a, b)
+    assert out["version_mismatch"]
+    assert "skipped" in out["verdict"]
+
+
+def test_format_diff_renders_verdict():
+    a = _build_summary()
+    a.fingerprint_version = 1
+    b = _build_summary()
+    b.fingerprint_version = 99
+    out = format_diff(diff_sessions(a, b))
+    assert "version_mismatch" in out or "mismatch" in out.lower()
+
+
+# === serialisation ===
+
+
+def test_summary_roundtrip():
+    summary = _build_summary()
+    payload = summary_to_json(summary)
+    # Must be JSON-serialisable
+    encoded = json.dumps(payload)
+    rebuilt = summary_from_json(json.loads(encoded))
+    assert rebuilt.session_id == summary.session_id
+    assert rebuilt.event_count == summary.event_count
+    assert len(rebuilt.clusters) == len(summary.clusters)
+    assert rebuilt.fingerprint_version == FINGERPRINT_VERSION
+
+
+def test_event_jsonl_roundtrip():
+    event = _event("[A foo]", 600, delta=12_400)
+    line = event_to_jsonl(event)
+    rebuilt = event_from_jsonl(line)
+    assert rebuilt.fingerprint == event.fingerprint
+    assert rebuilt.severity == Severity.CRITICAL
+
+
+def test_cluster_to_json_handles_enum():
+    summary = _build_summary()
+    payload = summary_to_json(summary)
+    for cluster in payload["clusters"]:
+        # Must be a plain string, not an enum repr
+        assert cluster["severity"] in {s.value for s in Severity}

--- a/tests/test_hang_sessions.py
+++ b/tests/test_hang_sessions.py
@@ -1,0 +1,253 @@
+"""Lifecycle + storage tests for common.hang_sessions."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from common.hang_pipeline import (
+    NormalisedEvent,
+    Severity,
+    SummaryBuilder,
+    compute_fingerprint,
+    event_to_jsonl,
+)
+from common.hang_sessions import SessionStore, _generate_session_id, _resolve_cutoff_ms
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SessionStore:
+    return SessionStore(tmp_path / "sessions")
+
+
+# === session ID ===
+
+
+def test_generate_session_id_format():
+    sid = _generate_session_id()
+    parts = sid.split("-")
+    assert len(parts) == 4
+    assert parts[0] == "hang"
+    assert len(parts[1]) == 8
+    assert len(parts[2]) == 6
+    assert len(parts[3]) == 4
+
+
+def test_generate_session_id_uniqueness():
+    # 4-hex suffix gives 65,536 values per same-second window; this proves the
+    # suffix is actually random, without inviting birthday-paradox flakiness.
+    ids = {_generate_session_id() for _ in range(20)}
+    assert len(ids) == 20
+
+
+# === create ===
+
+
+def test_create_lays_down_dir_with_initial_meta(store: SessionStore):
+    meta = store.create({"min_hang_ms": 200, "bundle_id": "com.example.app"})
+    session_dir = store.session_dir(meta.session_id)
+    assert session_dir.is_dir()
+    assert (session_dir / "meta.json").exists()
+    assert (session_dir / "events.jsonl").exists()
+    assert meta.status == "pending"
+    assert meta.pid is None
+
+
+def test_load_meta_roundtrips(store: SessionStore):
+    meta = store.create({"min_hang_ms": 250})
+    loaded = store.load_meta(meta.session_id)
+    assert loaded.session_id == meta.session_id
+    assert loaded.args["min_hang_ms"] == 250
+
+
+# === claim + wait ===
+
+
+def test_claim_worker_sets_running(store: SessionStore):
+    meta = store.create({})
+    claimed = store.claim_worker(meta.session_id, pid=os.getpid())
+    assert claimed.status == "running"
+    assert claimed.pid == os.getpid()
+
+
+def test_wait_for_worker_returns_when_running(store: SessionStore):
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    out = store.wait_for_worker(meta.session_id, timeout_seconds=0.5)
+    assert out.status == "running"
+
+
+def test_wait_for_worker_times_out(store: SessionStore):
+    meta = store.create({})
+    with pytest.raises(TimeoutError):
+        store.wait_for_worker(meta.session_id, timeout_seconds=0.2)
+
+
+# === events.jsonl ===
+
+
+def _norm(symbol: str, ms: float, delta: int) -> NormalisedEvent:
+    return NormalisedEvent(
+        delta_ms=delta,
+        process="MyApp",
+        pid=1,
+        duration_ms=ms,
+        severity=Severity.CRITICAL if ms >= 500 else Severity.WARN,
+        symbol=symbol,
+        message_prefix="prefix",
+        fingerprint=compute_fingerprint(symbol, "prefix"),
+    )
+
+
+def test_read_events_filters_sentinel(store: SessionStore):
+    meta = store.create({})
+    path = store.events_path(meta.session_id)
+    with open(path, "w") as handle:
+        handle.write(event_to_jsonl(_norm("[A]", 300, 100)) + "\n")
+        handle.write('{"event":"stream_ended","at_ms":1234}\n')
+        handle.write(event_to_jsonl(_norm("[B]", 600, 200)) + "\n")
+    events = store.read_events(meta.session_id)
+    assert len(events) == 2
+    assert {e.symbol for e in events} == {"[A]", "[B]"}
+
+
+def test_read_events_skips_corrupt_lines(store: SessionStore):
+    meta = store.create({})
+    path = store.events_path(meta.session_id)
+    with open(path, "w") as handle:
+        handle.write(event_to_jsonl(_norm("[A]", 300, 100)) + "\n")
+        handle.write("garbage that is not json\n")
+        handle.write(event_to_jsonl(_norm("[B]", 600, 200)) + "\n")
+    events = store.read_events(meta.session_id)
+    assert len(events) == 2
+
+
+# === stop + summary ===
+
+
+def test_stop_writes_summary_and_marks_stopped(store: SessionStore):
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    builder = SummaryBuilder(
+        session_id=meta.session_id,
+        started_at=meta.started_at,
+        duration_ms=10_000,
+    )
+    summary = builder.build([_norm("[A]", 600, 1000)])
+    store.stop(meta.session_id, summary)
+    loaded_meta = store.load_meta(meta.session_id)
+    assert loaded_meta.status == "stopped"
+    assert loaded_meta.stopped_at is not None
+    loaded_summary = store.load_summary(meta.session_id)
+    assert loaded_summary is not None
+    assert loaded_summary.event_count == 1
+
+
+def test_build_summary_reads_events_and_clusters(store: SessionStore):
+    meta = store.create({})
+    path = store.events_path(meta.session_id)
+    with open(path, "w") as handle:
+        for i in range(5):
+            handle.write(event_to_jsonl(_norm("[A]", 600, i * 100)) + "\n")
+        for i in range(3):
+            handle.write(event_to_jsonl(_norm("[B]", 300, 5_000 + i * 100)) + "\n")
+    summary = store.build_summary(
+        meta.session_id, matched_lines=8, total_lines=500, dropped_below_threshold=2
+    )
+    assert summary.event_count == 8
+    assert len(summary.clusters) == 2
+    assert summary.dropped_below_threshold == 2
+
+
+# === list / clear / prune ===
+
+
+def test_list_sessions_newest_first(store: SessionStore):
+    a = store.create({})
+    time.sleep(0.01)
+    b = store.create({})
+    listed = store.list_sessions()
+    assert [m.session_id for m in listed] == [b.session_id, a.session_id]
+
+
+def test_clear_removes_all_when_no_filter(store: SessionStore):
+    for _ in range(3):
+        store.create({})
+        time.sleep(0.001)
+    assert store.clear() == 3
+    assert store.list_sessions() == []
+
+
+def test_clear_older_than_filters_recent(store: SessionStore):
+    meta = store.create({})
+    deleted = store.clear(older_than="1h")
+    # Just-created session is younger than 1h; should NOT be deleted.
+    assert deleted == 0
+    assert store.list_sessions()[0].session_id == meta.session_id
+
+
+def test_clear_older_than_zero_deletes_all(store: SessionStore):
+    store.create({})
+    store.create({})
+    # An ``older than 0s`` cutoff is "everything not created in the future" → all gone.
+    deleted = store.clear(older_than="0s")
+    assert deleted == 2
+
+
+def test_prune_expired_uses_default_ttl(store: SessionStore):
+    meta = store.create({})
+    # TTL of 24h (default); fresh session should remain.
+    assert store.prune_expired() == 0
+    assert store.list_sessions()[0].session_id == meta.session_id
+
+
+# === signal_worker ===
+
+
+def test_signal_worker_returns_false_when_no_pid(store: SessionStore):
+    meta = store.create({})
+    # status=pending, pid=None
+    assert store.signal_worker(meta.session_id) is False
+
+
+def test_signal_worker_returns_false_for_dead_pid(store: SessionStore):
+    meta = store.create({})
+    # PID 1 typically refuses SIGTERM from non-root; emulates a dead process.
+    # Use a more reliable approach: a very high PID likely doesn't exist.
+    store.claim_worker(meta.session_id, pid=999_999)
+    # ProcessLookupError → returns False
+    assert store.signal_worker(meta.session_id) is False
+
+
+# === duration parser ===
+
+
+def test_resolve_cutoff_ms_accepts_all_units():
+    for token in ("30s", "5m", "1h", "2d"):
+        assert isinstance(_resolve_cutoff_ms(token), int)
+
+
+def test_resolve_cutoff_ms_rejects_invalid():
+    with pytest.raises(ValueError):
+        _resolve_cutoff_ms("bogus")
+
+
+# === atomic writes ===
+
+
+def test_meta_write_is_atomic(store: SessionStore):
+    meta = store.create({})
+    # No .tmp residue after write.
+    tmp = (store.session_dir(meta.session_id) / "meta.json.tmp")
+    assert not tmp.exists()
+
+
+def test_meta_json_is_valid(store: SessionStore):
+    meta = store.create({"foo": "bar"})
+    with open(store.session_dir(meta.session_id) / "meta.json") as handle:
+        payload = json.load(handle)
+    assert payload["args"]["foo"] == "bar"

--- a/tests/test_token_budgets.py
+++ b/tests/test_token_budgets.py
@@ -1,0 +1,74 @@
+"""Contract: --stop output ≤ 200 tokens, --get-details ≤ 2000 tokens (char/4)."""
+
+from __future__ import annotations
+
+from common.hang_pipeline import (
+    compress_to_budget,
+    estimate_tokens,
+    format_cluster_detail,
+    format_l0,
+    format_l1,
+    format_l2,
+)
+from tests.fixtures.sample_session import (
+    assert_token_budget,
+    make_events,
+    make_summary,
+)
+
+
+def test_l0_is_one_line_under_30_tokens():
+    summary = make_summary()
+    out = format_l0(summary)
+    assert "\n" not in out
+    assert_token_budget(out, 30)
+
+
+def test_l1_default_under_200_tokens():
+    """Issue #77 contract: default --stop output ≤ 200 tokens on 30s/50-event session."""
+    summary = make_summary()
+    out = format_l1(summary)
+    assert_token_budget(out, 200)
+
+
+def test_l2_full_under_2000_tokens():
+    """Issue #77 contract: --get-details (without --cluster) ≤ 2000 tokens."""
+    summary = make_summary()
+    out = format_l2(summary)
+    assert_token_budget(out, 2000)
+
+
+def test_l3_cluster_detail_under_2000_tokens():
+    summary = make_summary()
+    cluster = summary.clusters[0]
+    events = [e for e in make_events() if e.fingerprint == cluster.fingerprint]
+    out = format_cluster_detail(cluster, events)
+    assert_token_budget(out, 2000)
+
+
+def test_compress_to_budget_honours_tight_limits():
+    summary = make_summary()
+    # Tight budget should fall back to L0 (~20 tokens).
+    out = compress_to_budget(summary, max_tokens=30)
+    assert estimate_tokens(out) <= 30
+    assert "\n" not in out
+
+
+def test_compress_to_budget_uses_l1_at_default_window():
+    summary = make_summary()
+    out = compress_to_budget(summary, max_tokens=150)
+    assert estimate_tokens(out) <= 150
+
+
+def test_compress_to_budget_uses_l2_when_room():
+    summary = make_summary()
+    out = compress_to_budget(summary, max_tokens=1500)
+    assert estimate_tokens(out) <= 1500
+    # L2 reports a "Severity:" histogram line; L1 does not.
+    assert "Severity:" in out
+
+
+def test_compress_with_no_budget_returns_l1():
+    summary = make_summary()
+    out = compress_to_budget(summary, max_tokens=None)
+    assert "Drill:" in out


### PR DESCRIPTION
Closes #77.

## What

Evolves `hang_watcher.py` from a passive `tail -f`-style log stream into an **agent-native session recorder** with progressive disclosure. Default `--stop` output is **~80–120 tokens** (vs ~3–5k for v1 raw streaming) with explicit drill paths to per-cluster detail.

Branded **HangBuster** in `--help`, README, and SKILL.md; the file stays `hang_watcher.py` for backward compatibility with anything calling it post-PR #75.

## Architecture

Pure-function filter pipeline as the load-bearing abstraction:

```
parse → normalise → threshold → bucket → cluster → aggregate → rank → format
```

- `common/hang_pipeline.py` — 10 pure functions + dataclasses + token estimator (char/4) + budget compressor + diff intelligence
- `common/hang_sessions.py` — session dir CRUD with own layout (`~/.ios-simulator-skill/sessions/<id>/{meta.json, events.jsonl, summary.json}`); 4-hex session-id suffix avoids same-second collisions; atomic meta writes
- `hang_watcher.py` — new `HangBuster` class; legacy `HangWatcher` retained and refactored to delegate to the pipeline (no behaviour change)

## CLI surface (new)

| Subcommand | Purpose |
|---|---|
| `--start` | Detached worker, returns session ID |
| `--stop SESSION_ID` | Drain + summarise, emit L1 (~80–120 tokens) |
| `--get-details SESSION_ID [--cluster N \| --raw]` | L2 full summary / L3 per-event / L4 raw passthrough |
| `--list-sessions` | All stored sessions, newest first |
| `--clear-sessions [--older-than DURATION]` | Prune sessions |
| `--diff A B` | Cross-session regression report with verdict line |

New flags: `--min-hang-ms`, `--top N`, `--all`, `--auto-sample`, `--budget-tokens N`, `--terse`, `--cluster N`, `--resample`, `--raw`, `--older-than DURATION`. Hidden worker entry via `--worker-session-id` (`argparse.SUPPRESS`).

## Layered output

| Level | Tokens (char/4) | Trigger |
|---|---|---|
| L0 | ~20 | `--stop --terse` or budget < 100 |
| L1 | ~80–120 | `--stop` (default) |
| L2 | ~300 | `--stop --top 20` or `--get-details` |
| L3 | ~500/cluster | `--get-details --cluster N` |
| L4 | unbounded | `--get-details --raw` |

`--budget-tokens` picks the densest level that fits.

## Backward compat

`HangWatcher` class + `--watch` / `--since` modes untouched. Stateless parse helpers were extracted to `common/hang_pipeline.py`; `HangWatcher` keeps its public API and now delegates internally.

## Design fixes folded in from a pressure-test pass

- Worker writes its own `meta.json` with `os.getpid()` as first action → no pidfile race
- Parent never installs a signal handler; only the detached worker does (SIGTERM-driven flush)
- `events.jsonl` opened line-buffered + periodic `os.fsync` for crash-safe drain
- `select`-based readline timeout writes `{\"event\": \"stream_ended\"}` sentinel if the simulator reboots
- 4-hex session-id suffix prevents collisions for same-second `--start` calls
- `--auto-sample` debounced to one sample per cluster per session
- `fingerprint_version=1` written to `summary.json` with documented bump contract; `--diff` warns + skips structural compare on mismatch
- Stateless parse helpers extracted to pipeline; no duplicated logic

## Soft dependency

`--auto-sample` soft-imports `main_thread_sampler.py` (issue #62). If missing: stderr warning + placeholder `{\"stack\": null, \"reason\": \"main_thread_sampler not available\"}` in the cluster record.

## New env vars

| Var | Default |
|---|---|
| `IOS_SIM_HANG_MIN_MS` | 250 |
| `IOS_SIM_HANG_SESSION_TTL_HOURS` | 24 |
| `IOS_SIM_HANG_DEFAULT_TOP_N` | 3 |
| `IOS_SIM_HANG_BUDGET_TOKENS` | unset |

## Tests

Repo had no test infrastructure; this PR scaffolds it (pyproject.toml `[tool.pytest.ini_options]` + `tests/conftest.py` + `pythonpath` config).

**88 tests, all green:**
- `tests/test_hang_pipeline.py` — 51 unit tests covering every pipeline stage
- `tests/test_hang_sessions.py` — 23 lifecycle / TTL / atomicity tests
- `tests/test_token_budgets.py` — **8 contract tests** asserting L1 ≤ 200 tokens, L2/L3 ≤ 2000 tokens on a 50-event fixture (this is the issue-mandated contract)
- `tests/test_diff.py` — 6 diff tests (new critical, resolved cluster, drift, version mismatch)

Plus end-to-end CLI smoke verified: `--list-sessions`, `--stop` (L1), `--get-details` (L2), `--get-details --cluster N` (L3), `--diff` (regression verdict, JSON mode).

## Static analysis

- `black --check` clean
- `ruff check` clean (no new ignores added; addressed `UP042`, `RUF007`, `SIM105`, `RUF002`, `PLC0207`)

## Files

| Status | File | LOC |
|---|---|---|
| Modify | `hang_watcher.py` | +540 / −134 |
| Create | `common/hang_pipeline.py` | +630 |
| Create | `common/hang_sessions.py` | +355 |
| Modify | `SKILL.md` | +18 / −5 |
| Modify | `README.md` | +5 / −1 |
| Modify | `pyproject.toml` | +5 |
| Create | `tests/` | +1130 |

## Verification

```bash
# Static
black --check ios-simulator-skill/skills/ios-simulator-skill/scripts/
ruff check ios-simulator-skill/skills/ios-simulator-skill/scripts/

# Tests
pytest tests/ -v

# Manual smoke (needs booted simulator):
SID=\$(python ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py --start --min-hang-ms 200)
# ... interact with simulator ...
python ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py --stop \$SID
python ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py --get-details \$SID --cluster 1
python ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py --list-sessions
python ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py --clear-sessions --older-than 24h
```

## Out of scope (deferred)

- `fingerprint_version` migration story (recompute from `events.jsonl` on version bump) — documented contract is sufficient for v1
- Promoting `common/hang_pipeline.py` to a generic `common/log_filters.py` — AHA principle, wait for a second consumer