### PR TITLE
fix: append-only JSONL for auto_samples (closes #81)

### DIFF
--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
@@ -198,6 +198,41 @@ class SessionStore:
         with open(path) as handle:
             return summary_from_json(json.load(handle))
 
+    def stash_auto_sample(self, session_id: str, fingerprint: str, sample: dict) -> None:
+        """Append an auto-sample record to ``<session>/auto_samples.jsonl``.
+
+        Append-only JSONL avoids the read-modify-write race that an aggregate
+        JSON dict would have under concurrent worker stashes. Readers reduce
+        last-write-wins per fingerprint.
+        """
+        path = self._auto_samples_path(session_id)
+        line = json.dumps({"fingerprint": fingerprint, "sample": sample}, separators=(",", ":"))
+        with open(path, "a") as handle:
+            handle.write(line + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def read_auto_samples(self, session_id: str) -> dict[str, dict]:
+        """Return ``{fingerprint: sample}`` with last-write-wins per fingerprint."""
+        path = self._auto_samples_path(session_id)
+        if not path.exists():
+            return {}
+        samples: dict[str, dict] = {}
+        with open(path) as handle:
+            for raw in handle:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                fingerprint = payload.get("fingerprint")
+                if fingerprint is None:
+                    continue
+                samples[fingerprint] = payload.get("sample")
+        return samples
+
     def read_events(self, session_id: str) -> list:
         """Read all events.jsonl lines, returning NormalisedEvent instances.
 
@@ -306,6 +341,9 @@ class SessionStore:
 
     def _summary_path(self, session_id: str) -> Path:
         return self.base_dir / session_id / "summary.json"
+
+    def _auto_samples_path(self, session_id: str) -> Path:
+        return self.base_dir / session_id / "auto_samples.jsonl"
 
     def _write_meta(self, meta: SessionMeta) -> None:
         path = self._meta_path(meta.session_id)

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -693,19 +693,13 @@ class HangBuster:
         except RuntimeError as error:
             raise RuntimeError(str(error)) from error
 
-    def _stash_auto_sample(self, session_id: str, normalised, sample: dict | None) -> None:
-        """Record an auto-sample side-channel for later cluster annotation."""
-        sample_path = self.store.session_dir(session_id) / "auto_samples.json"
-        existing = {}
-        if sample_path.exists():
-            try:
-                with open(sample_path) as handle:
-                    existing = json.load(handle)
-            except (OSError, json.JSONDecodeError):
-                existing = {}
-        existing[normalised.fingerprint] = sample
-        with open(sample_path, "w") as handle:
-            json.dump(existing, handle)
+    def _stash_auto_sample(self, session_id: str, normalised, sample: dict) -> None:
+        """Record an auto-sample side-channel for later cluster annotation.
+
+        Delegates to SessionStore's append-only JSONL writer — concurrent stashes
+        from a busy worker no longer race against each other.
+        """
+        self.store.stash_auto_sample(session_id, normalised.fingerprint, sample)
 
 
 def _attempt_auto_sample(pid: int) -> dict:

--- a/tests/test_hang_sessions.py
+++ b/tests/test_hang_sessions.py
@@ -251,3 +251,67 @@ def test_meta_json_is_valid(store: SessionStore):
     with open(store.session_dir(meta.session_id) / "meta.json") as handle:
         payload = json.load(handle)
     assert payload["args"]["foo"] == "bar"
+
+
+# === auto_samples (JSONL) ===
+
+
+def test_stash_auto_sample_appends_jsonl(store: SessionStore):
+    meta = store.create({})
+    store.stash_auto_sample(meta.session_id, "fp:aaa", {"stack": ["a", "b"], "reason": "ok"})
+    store.stash_auto_sample(meta.session_id, "fp:bbb", {"stack": ["c"], "reason": "ok"})
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert set(samples.keys()) == {"fp:aaa", "fp:bbb"}
+    assert samples["fp:aaa"]["stack"] == ["a", "b"]
+    assert samples["fp:bbb"]["stack"] == ["c"]
+
+
+def test_stash_auto_sample_last_write_wins_per_fingerprint(store: SessionStore):
+    meta = store.create({})
+    store.stash_auto_sample(meta.session_id, "fp:dup", {"reason": "first"})
+    store.stash_auto_sample(meta.session_id, "fp:dup", {"reason": "second"})
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert samples["fp:dup"]["reason"] == "second"
+
+
+def test_read_auto_samples_returns_empty_when_missing(store: SessionStore):
+    meta = store.create({})
+    assert store.read_auto_samples(meta.session_id) == {}
+
+
+def test_concurrent_stash_drops_nothing(store: SessionStore):
+    """Two threads stashing in tight succession must both land — append-only avoids the
+    read-modify-write race the old auto_samples.json had."""
+    import threading
+
+    meta = store.create({})
+    fingerprints = [f"fp:{i:04d}" for i in range(50)]
+    threads = [
+        threading.Thread(
+            target=store.stash_auto_sample,
+            args=(meta.session_id, fp, {"reason": fp}),
+        )
+        for fp in fingerprints
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert set(samples.keys()) == set(fingerprints)
+
+
+def test_read_auto_samples_skips_corrupt_lines(store: SessionStore):
+    meta = store.create({})
+    # Manually corrupt the file with one bad line between two good ones.
+    path = store.session_dir(meta.session_id) / "auto_samples.jsonl"
+    with open(path, "w") as handle:
+        handle.write(json.dumps({"fingerprint": "fp:1", "sample": {"reason": "good"}}) + "\n")
+        handle.write("not-json\n")
+        handle.write(json.dumps({"fingerprint": "fp:2", "sample": {"reason": "good"}}) + "\n")
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert set(samples.keys()) == {"fp:1", "fp:2"}


### PR DESCRIPTION
Closes #81.

## Problem

The HangBuster worker's `_stash_auto_sample` performed a read-modify-write on `auto_samples.json` (an aggregate dict) with no locking. Two stashes for different fingerprints arriving close together could race — one stash's write clobbered the other's, silently dropping the lost entry.

## Fix

Switch the on-disk format to **append-only JSONL** (`auto_samples.jsonl`), one record per line. Mirrors the existing `events.jsonl` discipline (line-buffered + `fsync`). Append is atomic at the syscall level — no race possible.

### New SessionStore surface

```python
store.stash_auto_sample(session_id, fingerprint, sample)  # append one line
store.read_auto_samples(session_id)                        # last-write-wins per fp
```

### Worker change

`HangBuster._stash_auto_sample` now just delegates — no local file I/O.

## Tests

5 new in \`tests/test_hang_sessions.py\`:
- \`test_stash_auto_sample_appends_jsonl\` — two different fingerprints, both readable
- \`test_stash_auto_sample_last_write_wins_per_fingerprint\` — duplicate fp behaviour
- \`test_read_auto_samples_returns_empty_when_missing\` — no file present
- \`test_concurrent_stash_drops_nothing\` — **50 threads** stashing distinct fps, all land
- \`test_read_auto_samples_skips_corrupt_lines\` — robustness on bad JSONL

## Compat

No external readers of the old \`auto_samples.json\` exist (\`rg auto_samples\` shows only the writer). Old files on disk become inert — TTL pruning sweeps them.

## Verification

\`\`\`
ruff check: All checks passed
black --check: 42 files would be left unchanged
python -m pytest tests/: 93 passed (was 88)
pytest tests/: 93 passed
\`\`\`