### PR TITLE
fix: handle zero-duration clusters in diff_sessions (closes #79)

### DIFF
--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
@@ -506,10 +506,13 @@ def format_diff(diff: dict) -> str:
     if drift:
         lines.append(f"Drift ({len(drift)}):")
         for entry in drift[:5]:
+            # inf delta (0 → N) renders as "new"; finite deltas keep the % suffix.
+            delta = entry["delta_pct"]
+            delta_str = "new" if delta == float("inf") else f"{delta:+.0f}%"
             lines.append(
                 f"  ~ {entry['symbol_or_prefix']}: "
                 f"{entry['max_duration_ms_a']:.0f} → {entry['max_duration_ms_b']:.0f}ms "
-                f"({entry['delta_pct']:+.0f}%)"
+                f"({delta_str})"
             )
     if stable:
         lines.append(f"Stable: {stable} cluster(s) unchanged")
@@ -583,10 +586,18 @@ def diff_sessions(
     stable = 0
     for key in shared_keys:
         ca, cb = a_map[key], b_map[key]
-        if ca.max_duration_ms == 0:
+        if ca.max_duration_ms == 0 and cb.max_duration_ms == 0:
+            stable += 1
             continue
-        delta_pct = (cb.max_duration_ms - ca.max_duration_ms) / ca.max_duration_ms * 100
-        if abs(delta_pct) >= drift_threshold_pct:
+        if ca.max_duration_ms == 0:
+            # 0 → N: a previously-silent cluster now hangs; treat as max worsening.
+            delta_pct: float = float("inf")
+        elif cb.max_duration_ms == 0:
+            # N → 0: cluster present in A but flat in B; fully improved.
+            delta_pct = -100.0
+        else:
+            delta_pct = (cb.max_duration_ms - ca.max_duration_ms) / ca.max_duration_ms * 100
+        if delta_pct == float("inf") or abs(delta_pct) >= drift_threshold_pct:
             drift.append(
                 {
                     "fingerprint": key,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -131,3 +131,88 @@ def test_format_diff_version_mismatch_carries_warning():
     b.fingerprint_version = 99
     out = format_diff(diff_sessions(a, b))
     assert "mismatch" in out.lower()
+
+
+# === zero-duration drift handling (#79) ===
+
+
+def _zero_dur_summary(session_id: str, clusters: dict[str, float]) -> "SessionSummary":
+    """Build a SessionSummary with a controlled fingerprint → max_duration_ms map."""
+    from common.hang_pipeline import Cluster, NormalisedEvent, SessionSummary, Severity
+
+    cluster_list = [
+        Cluster(
+            fingerprint=fp,
+            count=1,
+            max_duration_ms=max_dur,
+            total_duration_ms=max_dur,
+            first_delta_ms=0,
+            severity=Severity.CRITICAL if max_dur >= 500 else Severity.MINOR,
+            symbol_or_prefix=fp,
+            sample_event=NormalisedEvent(
+                delta_ms=0,
+                process="p",
+                pid=1,
+                duration_ms=max_dur,
+                severity=Severity.CRITICAL if max_dur >= 500 else Severity.MINOR,
+                symbol=fp,
+                message_prefix=fp,
+                fingerprint=fp,
+            ),
+        )
+        for fp, max_dur in clusters.items()
+    ]
+    return SessionSummary(
+        session_id=session_id,
+        started_at="t",
+        duration_ms=1000,
+        event_count=len(cluster_list),
+        dropped_below_threshold=0,
+        matched_lines=len(cluster_list),
+        total_lines=len(cluster_list),
+        clusters=cluster_list,
+        aggregates={},
+    )
+
+
+def test_diff_zero_to_zero_counts_as_stable():
+    a = _zero_dur_summary("hang-a", {"fp:silent": 0.0})
+    b = _zero_dur_summary("hang-b", {"fp:silent": 0.0})
+    result = diff_sessions(a, b)
+    assert result["stable_count"] == 1
+    assert not result["drift"]
+
+
+def test_diff_zero_to_nonzero_is_drift_with_inf_delta():
+    a = _zero_dur_summary("hang-a", {"fp:newsignal": 0.0})
+    b = _zero_dur_summary("hang-b", {"fp:newsignal": 800.0})
+    result = diff_sessions(a, b)
+    assert len(result["drift"]) == 1
+    assert result["drift"][0]["delta_pct"] == float("inf")
+    assert result["drift"][0]["max_duration_ms_a"] == 0.0
+    assert result["drift"][0]["max_duration_ms_b"] == 800.0
+
+
+def test_diff_nonzero_to_zero_is_drift_with_minus_one_hundred():
+    a = _zero_dur_summary("hang-a", {"fp:fixed": 800.0})
+    b = _zero_dur_summary("hang-b", {"fp:fixed": 0.0})
+    result = diff_sessions(a, b)
+    assert len(result["drift"]) == 1
+    assert result["drift"][0]["delta_pct"] == -100.0
+
+
+def test_diff_nonzero_unchanged_still_uses_threshold():
+    # Regression guard — the new zero-handling branches must not break the standard path.
+    a = _zero_dur_summary("hang-a", {"fp:steady": 500.0})
+    b = _zero_dur_summary("hang-b", {"fp:steady": 505.0})  # 1% drift, well under 20% threshold
+    result = diff_sessions(a, b)
+    assert result["stable_count"] == 1
+    assert not result["drift"]
+
+
+def test_format_diff_renders_inf_delta_as_new():
+    a = _zero_dur_summary("hang-a", {"fp:newsignal": 0.0})
+    b = _zero_dur_summary("hang-b", {"fp:newsignal": 800.0})
+    out = format_diff(diff_sessions(a, b))
+    assert "new" in out
+    assert "inf" not in out.lower()


### PR DESCRIPTION
Closes #79.

## Problem

`diff_sessions()` had a divide-by-zero guard that did a bare `continue`:

```python
if ca.max_duration_ms == 0:
    continue
```

A zero-duration cluster in session A simply vanished from the diff. Worse, a real regression — a previously-silent cluster (0 ms) that started hanging (e.g. 800 ms in B) — was dropped entirely instead of being flagged as drift.

## Fix

Replace with explicit 4-way branching:

| Case | Result |
|---|---|
| `A == 0, B == 0` | `stable++` |
| `A == 0, B > 0` | drift, `delta_pct = float("inf")` (worsened, "new signal") |
| `A > 0, B == 0` | drift, `delta_pct = -100.0` (fully improved) |
| `A > 0, B > 0` | existing percentage logic |

The `inf` delta is special-cased in `format_diff` to render as `new` rather than `+inf%`.

## Tests

5 new in `tests/test_diff.py`:
- `test_diff_zero_to_zero_counts_as_stable`
- `test_diff_zero_to_nonzero_is_drift_with_inf_delta`
- `test_diff_nonzero_to_zero_is_drift_with_minus_one_hundred`
- `test_diff_nonzero_unchanged_still_uses_threshold` (regression guard)
- `test_format_diff_renders_inf_delta_as_new`

A small helper `_zero_dur_summary()` builds `SessionSummary` instances with controlled `max_duration_ms` per cluster — keeps the test isolated from the event-aggregation pipeline.

## Verification

```
ruff check: All checks passed
black --check: 42 files would be left unchanged
python -m pytest tests/: 93 passed (was 88)
pytest tests/: 93 passed
```