### PR TITLE
fix+feat+test: HangBuster review follow-ups + capture-path bugs + raw NDJSON mode (closes #79 #80 #81 #82 #83 #84 #85)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "ios-simulator-skill",
       "source": "./ios-simulator-skill",
-      "description": "22 production-ready scripts for iOS app testing, building, and automation"
+      "description": "29 production-ready scripts for iOS app testing, building, and automation"
     }
   ]
 }

--- a/.github/workflows/validate-version.yml
+++ b/.github/workflows/validate-version.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check SKILL.md for version reference
         run: |
-          if ! grep -q "${{ steps.version.outputs.number }}" ios-simulator-skill/SKILL.md; then
+          if ! grep -q "${{ steps.version.outputs.number }}" ios-simulator-skill/skills/ios-simulator-skill/SKILL.md; then
             echo "⚠️  WARNING: Version ${{ steps.version.outputs.number }} not mentioned in SKILL.md"
             echo "Consider adding version info to the SKILL.md frontmatter or description"
           else

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ DerivedData/
 *.zip
 
 # Local skill config (user-specific)
-skill/scripts/.claude/skills/ios-simulator-skill/config.json
+ios-simulator-skill/skills/ios-simulator-skill/config.json
 
 # Other
 .claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code and developers working with this repo
 
 ## Project Overview
 
-iOS Simulator Skill is a production-ready Agent Skill providing 21 scripts for iOS app building, testing, and automation. It wraps Apple's `xcrun simctl` and Facebook's `idb` tools with semantic interfaces designed for AI agents and developers.
+iOS Simulator Skill is a production-ready Agent Skill providing 29 scripts for iOS app building, testing, and automation. It wraps Apple's `xcrun simctl` and Facebook's `idb` tools with semantic interfaces designed for AI agents and developers.
 
 **Key Statistics:**
-- 27 production scripts (~9,000 lines)
-- 5 script categories (Build, Navigation, Testing, Permissions, Lifecycle)
+- 29 production scripts
+- 7 script categories (Build, Device State, Navigation, Testing, Permissions, Simulator Discovery, Lifecycle)
 - 7 shared utility modules (~2,400 lines)
 - 100% token-optimized default output
 - 88 unit tests across pipeline / sessions / token-budget / diff (run `pytest tests/`)
@@ -23,7 +23,7 @@ ios-simulator-skill/            # Repository root
 │   └── skills/
 │       └── ios-simulator-skill/
 │           ├── SKILL.md       # Entry point (table of contents)
-│           └── scripts/       # 27 production scripts
+│           └── scripts/       # 29 production scripts
 │               ├── build_and_test.py
 │               ├── xcode/     # Xcode integration module
 │               ├── log_monitor.py
@@ -122,6 +122,10 @@ python scripts/simctl_boot.py --type iPhone
 - **build_and_test.py**: Build with progressive disclosure
 - **log_monitor.py**: Real-time log monitoring
 
+### Device State (2)
+- **appearance.py**: Dark mode, Dynamic Type, locale/region
+- **location.py**: GPS coordinates, city presets, GPX route playback
+
 ### Navigation & Interaction (5)
 - **screen_mapper.py**: Analyze screen
 - **navigator.py**: Semantic element finding
@@ -129,19 +133,26 @@ python scripts/simctl_boot.py --type iPhone
 - **keyboard.py**: Text input and keys
 - **app_launcher.py**: App lifecycle
 
-### Testing & Analysis (6)
+### Testing & Analysis (9)
 - **accessibility_audit.py**: WCAG compliance
 - **visual_diff.py**: Screenshot comparison
 - **test_recorder.py**: Test documentation
 - **app_state_capture.py**: Debugging snapshots
 - **sim_health_check.sh**: Environment verification
+- **model_inspector.py**: Core Data and SwiftData model inspection
+- **container.py**: App sandbox files, UserDefaults, Core Data store paths
 - **hang_watcher.py** (HangBuster): session-scoped hang recorder with progressive disclosure (`--start`/`--stop`/`--get-details`/`--diff`); legacy `--watch`/`--since` paths preserved
+- **localization_audit.py**: String catalog gaps, missing keys, placeholder mismatches
 
 ### Advanced Testing & Permissions (4)
 - **clipboard.py**: Clipboard management
 - **status_bar.py**: Status bar control
 - **push_notification.py**: Push notifications
 - **privacy_manager.py**: Permission management
+
+### Simulator Discovery (2)
+- **sim_list.py**: List simulators with progressive disclosure (96% token reduction)
+- **simulator_selector.py**: Suggest best simulator from recent use, latest iOS, boot status
 
 ### Device Lifecycle Management (5)
 - **simctl_boot.py**: Boot device

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ python scripts/simctl_boot.py --type iPhone
 - **sim_health_check.sh**: Environment verification
 - **model_inspector.py**: Core Data and SwiftData model inspection
 - **container.py**: App sandbox files, UserDefaults, Core Data store paths
-- **hang_watcher.py** (HangBuster): session-scoped hang recorder with progressive disclosure (`--start`/`--stop`/`--get-details`/`--diff`); legacy `--watch`/`--since` paths preserved
+- **hang_watcher.py** (HangBuster): session-scoped hang recorder with progressive disclosure (`--start`/`--stop`/`--get-details`/`--diff`); raw NDJSON mode (`--raw-capture` + size cap + gzip) for `jq` exploration; bounded auto-restart on stream EOF (`IOS_SIM_HANG_MAX_RESTARTS`) so crashed workers are marked `crashed` not stale `running`; aggregate disk cap (`IOS_SIM_HANG_TOTAL_CAP_MB`) pruned on every `--start`; legacy `--watch`/`--since` paths preserved
 - **localization_audit.py**: String catalog gaps, missing keys, placeholder mismatches
 
 ### Advanced Testing & Permissions (4)
@@ -186,11 +186,14 @@ Pure-function HangBuster filter pipeline (parse → normalise → threshold → 
 - `diff_sessions()` with `fingerprint_version` guard
 - Dataclasses: `NormalisedEvent`, `Cluster`, `SessionSummary`, `Severity` (StrEnum)
 
-### hang_sessions.py (~355 lines)
-- `SessionStore`: filesystem-backed session repository at `~/.ios-simulator-skill/sessions/<id>/{meta.json, events.jsonl, summary.json}`
+### hang_sessions.py (~400 lines)
+- `SessionStore`: filesystem-backed session repository at `~/.ios-simulator-skill/sessions/<id>/{meta.json, events.jsonl, summary.json, raw.ndjson.gz?, auto_samples.jsonl?}`
 - Session ID format: `hang-YYYYMMDD-HHmmss-<4hex>` (random suffix avoids same-second collisions)
 - Atomic meta writes (`.tmp` + `replace`); worker writes its own pid (no pidfile race)
+- Status state machine: `pending → running → (stopped | crashed)`. `mark_crashed` records `stopped_at_ms` so `build_summary` reflects the capture window, not the time of inspection. `persist_worker_counters` preserves terminal status (cannot clobber CRASHED/STOPPED back to RUNNING).
 - TTL prune via `IOS_SIM_HANG_SESSION_TTL_HOURS` on every `--start`
+- Aggregate cap via `IOS_SIM_HANG_TOTAL_CAP_MB` (`prune_to_aggregate_cap`) — oldest-first eviction; runs alongside TTL prune on every `--start`
+- `raw_path()` + `session_total_bytes()` accessors for raw-capture mode
 
 ## Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Every script supports `--help` and `--json`. See **SKILL.md** for the complete r
 | `sim_health_check.sh` | Verify environment (Xcode, simctl, IDB, Python) | — |
 | `model_inspector.py` | Inspect Core Data / SwiftData models from project files | `--project-path`, `--raw`, `--show-versions` |
 | `container.py` | Inspect app sandbox: list, cat, UserDefaults, Core Data, export | `--ls`, `--cat`, `--userdefaults`, `--core-data-path`, `--export` |
-| `hang_watcher.py` (HangBuster) | Record + summarise `os_log` hang events with progressive disclosure (session mode + legacy stream) | `--start`, `--stop`, `--get-details`, `--list-sessions`, `--diff`, `--budget-tokens`, `--auto-sample` (legacy: `--watch`, `--since`) |
+| `hang_watcher.py` (HangBuster) | Record + summarise `os_log` hang events with progressive disclosure (session mode + raw NDJSON + legacy stream); auto-restart on stream death, automatic disk-cap cleanup | `--start [--raw-capture --max-size-mb N --no-gzip]`, `--stop`, `--get-details`, `--list-sessions`, `--diff`, `--budget-tokens`, `--auto-sample` (legacy: `--watch`, `--since`) |
 | `localization_audit.py` | Audit `.xcstrings` catalogs for missing keys, unused keys, placeholder mismatches | `--catalog`, `--source`, `--strict` |
 
 #### Permissions & Environment
@@ -194,11 +194,13 @@ How long to wait on `xcrun simctl` operations.
 | `IOS_SIM_LOG_LINE_MAX` | `300` (chars) | Per-line truncation. Crash messages with full Swift symbol mangling can exceed 200 chars; raise if you see “…” cutting off the actionable bit. |
 | `IOS_SIM_LOG_TAIL` | `200` (lines) | Recent log lines shown in verbose mode and JSON `sample_logs`. Also used by xcode log excerpt. Lower for tighter context, higher for richer post-mortems. |
 | `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors / warnings in JSON output. Raise if you're piping into a dashboard that needs the full picture. |
-| `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py`. The default catches RunningBoard watchdog kills, explicit "Hang detected" messages, and main-thread hang annotations. Narrow it (e.g. `subsystem == "com.apple.runningboard"`) for major-hangs-only; broaden for noisier subsystems. |
+| `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py`. The default catches RunningBoard watchdog kills, explicit "Hang detected" messages, and main-thread hang annotations. Hang events originate from system daemons (RunningBoard, SpringBoard, watchdog) — *not* the target app's process — so the predicate intentionally stays simulator-global. `--bundle-id` is applied post-parse against the event payload, never ANDed into the predicate. |
 | `IOS_SIM_HANG_MIN_MS` | `250` | HangBuster threshold: events below this duration never reach disk. |
-| `IOS_SIM_HANG_SESSION_TTL_HOURS` | `24` | HangBuster session prune age. |
+| `IOS_SIM_HANG_SESSION_TTL_HOURS` | `24` | HangBuster session prune age. Pruning runs on every `--start`. |
 | `IOS_SIM_HANG_DEFAULT_TOP_N` | `3` | Default top-N clusters in `--stop` L1 output. |
 | `IOS_SIM_HANG_BUDGET_TOKENS` | _(unset)_ | Default token budget for `--stop` (picks L0/L1/L2 to fit). |
+| `IOS_SIM_HANG_MAX_RESTARTS` | `3` | HangBuster worker: bounded `log stream` respawn attempts on EOF/subprocess death before the session is marked `crashed`. Set to `0` to disable auto-restart. |
+| `IOS_SIM_HANG_TOTAL_CAP_MB` | `100` | HangBuster aggregate disk cap. When total session-state exceeds this on `--start`, oldest sessions are dropped first. Set to `0` to disable. |
 
 ### UI navigation & screen mapping
 

--- a/ios-simulator-skill/.claude-plugin/plugin.json
+++ b/ios-simulator-skill/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-simulator-skill",
-  "description": "22 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
+  "description": "29 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management.",
   "author": {
     "name": "Conor Luddy"
   },

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -164,9 +164,43 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
       - Filter pipeline: parse → normalise → threshold → bucket → cluster → aggregate → rank → format (in `common/hang_pipeline.py`)
       - `--budget-tokens N` picks the densest level (L0/L1/L2) that fits; `--terse` forces L0
       - `--auto-sample` captures a main-thread stack on first event per cluster (soft dependency: `main_thread_sampler.py` #62; graceful no-op if absent)
+    - **Raw capture mode (full fidelity for `jq` exploration):** skip the clustering pipeline, dump every matching log line verbatim to `raw.ndjson`
+      - `--start --raw-capture [--max-size-mb 10] [--no-gzip]` — spawns `log stream --style ndjson`
+      - Per-session size cap (`--max-size-mb`, default 10) — worker stops cleanly on cap; `extras.truncated=true`
+      - `--stop` gzips `raw.ndjson` → `raw.ndjson.gz` (~15–19× compression; `--no-gzip` opts out)
+      - `--get-details SESSION_ID` on a raw session prints the path with a `zcat | jq ...` hint
+    - **Resilience (auto-restart on stream death):** EOF or subprocess death triggers a `stream_died` event then a bounded restart with 2s backoff. After `IOS_SIM_HANG_MAX_RESTARTS` (default 3) the session is marked `crashed`, never left in stale `running` state. `--list-sessions` shows `capture=Xs` and `restarts=N`.
+    - **Cleanup is automatic:** TTL prune (`IOS_SIM_HANG_SESSION_TTL_HOURS`, default 24h) + aggregate cap (`IOS_SIM_HANG_TOTAL_CAP_MB`, default 100 MB, oldest-first eviction) both run on every `--start`.
     - **Legacy modes (unchanged for backward compat):** `--watch [--duration N]` (live stream) and `--since 5m` (historical)
-    - Filters: `--bundle-id`, `--predicate` (also via `IOS_SIM_HANG_PREDICATE`)
-    - All output supports `--json`; session storage at `~/.ios-simulator-skill/sessions/<id>/{meta.json,events.jsonl,summary.json}`
+    - Filters: `--bundle-id` (post-parse — hang capture stays simulator-global so RunningBoard/SpringBoard events are kept), `--predicate` (also via `IOS_SIM_HANG_PREDICATE`)
+    - All output supports `--json`; session storage at `~/.ios-simulator-skill/sessions/<id>/{meta.json,events.jsonl,summary.json,raw.ndjson.gz}`
+
+    **Quick start (summarised mode):**
+    ```bash
+    SID=$(python scripts/hang_watcher.py --start --min-hang-ms 200)
+    # ... interact with the simulator (open sheets, scroll, navigate) ...
+    python scripts/hang_watcher.py --stop $SID                  # token-tight L1 summary
+    python scripts/hang_watcher.py --get-details $SID --cluster 1  # drill into cluster 1
+    python scripts/hang_watcher.py --diff $SID_BASELINE $SID    # cross-session regression
+    ```
+
+    **Quick start (raw capture + `jq` exploration):**
+    ```bash
+    SID=$(python scripts/hang_watcher.py --start --raw-capture --max-size-mb 5)
+    # ... interact with the simulator ...
+    python scripts/hang_watcher.py --stop $SID
+    # → "Session ...: raw mode, 737 lines, 0.96 MB → 0.05 MB gzipped"
+
+    # Top processes by event count:
+    zcat ~/.ios-simulator-skill/sessions/$SID/raw.ndjson.gz \
+      | jq -s 'group_by(.processImagePath) | map({proc: (.[0].processImagePath | split("/") | last), n: length}) | sort_by(-.n) | .[:5]'
+
+    # All RunningBoard assertion invalidations:
+    zcat .../raw.ndjson.gz | jq -c 'select(.subsystem == "com.apple.runningboard" and (.eventMessage | startswith("Invalidating")))'
+
+    # Hangs per minute:
+    zcat .../raw.ndjson.gz | jq -r '.timestamp[:16]' | sort | uniq -c
+    ```
 
 18. **localization_audit.py** - Detect string catalog gaps, missing keys, and placeholder mismatches
     - Report missing and `needs_review`/`new` keys per locale in `.xcstrings` catalogs
@@ -296,11 +330,13 @@ Most operational limits can be tuned via environment variables. Defaults work fo
 | `IOS_SIM_CACHE_MAX_ENTRIES` | `500` | Max entries in progressive disclosure cache (LRU eviction) |
 | `IOS_SIM_CACHE_TTL_HOURS` | `1` | Cache entry expiration |
 | `IOS_SIM_ERASE_TIMEOUT` | `90` | Wait-for-erase timeout (seconds) |
-| `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py` (default catches RunningBoard kills + "Hang detected" + main-thread hangs) |
+| `IOS_SIM_HANG_PREDICATE` | _(default)_ | Override the `os_log` predicate used by `hang_watcher.py` (default catches RunningBoard kills + "Hang detected" + main-thread hangs). Hang events originate from system daemons (RunningBoard, SpringBoard) so the predicate stays simulator-global — `--bundle-id` is applied post-parse, not ANDed in. |
 | `IOS_SIM_HANG_MIN_MS` | `250` | HangBuster threshold — events below this duration never reach disk (smaller = more sensitive, larger summaries) |
 | `IOS_SIM_HANG_SESSION_TTL_HOURS` | `24` | HangBuster session prune age; pruning runs on every `--start` |
 | `IOS_SIM_HANG_DEFAULT_TOP_N` | `3` | Default top-N clusters in `--stop` L1 output |
 | `IOS_SIM_HANG_BUDGET_TOKENS` | _(unset)_ | Default token budget for `--stop` (picks L0/L1/L2 to fit) |
+| `IOS_SIM_HANG_MAX_RESTARTS` | `3` | HangBuster worker: max `log stream` respawn attempts on EOF/subprocess death before the session is marked `crashed` |
+| `IOS_SIM_HANG_TOTAL_CAP_MB` | `100` | HangBuster aggregate disk cap. When total session-state exceeds this on `--start`, oldest sessions are dropped first. Set to `0` to disable. |
 | `IOS_SIM_LOG_JSON_CAP` | `100` | Max errors/warnings in `log_monitor.py` JSON output |
 | `IOS_SIM_LOG_LINE_MAX` | `300` | Per-line truncation in log summaries |
 | `IOS_SIM_LOG_TAIL` | `200` | Lines of log tail in verbose / sample output |

--- a/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
+++ b/ios-simulator-skill/skills/ios-simulator-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ios-simulator-skill
 version: 1.5.0
-description: 27 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
+description: 29 production-ready scripts for iOS app testing, building, and automation. Provides semantic UI navigation, build automation, accessibility testing, and simulator lifecycle management. Optimized for AI agents with minimal token output.
 ---
 
 # iOS Simulator Skill
@@ -40,7 +40,7 @@ Use this priority:
 
 Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree costs 10–50 tokens in default mode.
 
-## 27 Production Scripts
+## 29 Production Scripts
 
 ### Build & Development (2 scripts)
 
@@ -200,36 +200,53 @@ Screenshots cost 1,600–6,300 tokens depending on size. The accessibility tree 
     - Audit trail with test scenario tracking
     - Options: `--bundle-id`, `--grant`, `--revoke`, `--reset`, `--list`, `--json`
 
+### Simulator Discovery (2 scripts)
+
+23. **sim_list.py** - List simulators with progressive disclosure
+    - Concise summary by default (total / available / booted)
+    - Full details on demand via cache IDs
+    - Filter by device type
+    - Suggest recommended simulators with `--suggest`
+    - 96% token reduction vs raw `simctl list` (57k → 2k tokens)
+    - Options: `--get-details`, `--suggest`, `--device-type`, `--json`
+
+24. **simulator_selector.py** - Suggest the best simulator for the job
+    - Ranks candidates by recent use (from `config.json`), latest iOS, common test models, and boot status
+    - List all available simulators with `--list`
+    - Boot a selected simulator directly with `--boot`
+    - JSON output for programmatic use
+    - Options: `--suggest`, `--list`, `--boot`, `--json`
+
 ### Device Lifecycle Management (5 scripts)
 
-23. **simctl_boot.py** - Boot simulators with optional readiness verification
+25. **simctl_boot.py** - Boot simulators with optional readiness verification
     - Boot by UDID or device name
     - Wait for device ready with timeout
     - Batch boot operations (--all, --type)
     - Performance timing
     - Options: `--udid`, `--name`, `--wait-ready`, `--timeout`, `--all`, `--type`, `--json`
 
-24. **simctl_shutdown.py** - Gracefully shutdown simulators
+26. **simctl_shutdown.py** - Gracefully shutdown simulators
     - Shutdown by UDID or device name
     - Optional verification of shutdown completion
     - Batch shutdown operations
     - Options: `--udid`, `--name`, `--verify`, `--timeout`, `--all`, `--type`, `--json`
 
-25. **simctl_create.py** - Create simulators dynamically
+27. **simctl_create.py** - Create simulators dynamically
     - Create by device type and iOS version
     - List available device types and runtimes
     - Custom device naming
     - Returns UDID for CI/CD integration
     - Options: `--device`, `--runtime`, `--name`, `--list-devices`, `--list-runtimes`, `--json`
 
-26. **simctl_delete.py** - Permanently delete simulators
+28. **simctl_delete.py** - Permanently delete simulators
     - Delete by UDID or device name
     - Safety confirmation by default (skip with --yes)
     - Batch delete operations
     - Smart deletion (--old N to keep N per device type)
     - Options: `--udid`, `--name`, `--yes`, `--all`, `--type`, `--old`, `--json`
 
-27. **simctl_erase.py** - Factory reset simulators without deletion
+29. **simctl_erase.py** - Factory reset simulators without deletion
     - Preserve device UUID (faster than delete+create)
     - Erase all, by type, or booted simulators
     - Optional verification

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
@@ -14,6 +14,7 @@ dependency-free.
 
 from __future__ import annotations
 
+import hashlib
 import itertools
 import json
 import math
@@ -24,9 +25,13 @@ from enum import StrEnum
 
 # === CONSTANTS ===
 
-FINGERPRINT_VERSION = 1
+FINGERPRINT_VERSION = 2
 """Bump when normalise_message, compute_fingerprint, or severity boundaries change.
-`--diff` skips structural comparison across mismatched versions."""
+`--diff` skips structural comparison across mismatched versions.
+
+v2 (2026-05): compute_fingerprint() now hashes its input with sha256[:16].
+v1 used the raw symbol / normalised prefix — collision risk when heavy upstream
+normalisation reduced distinct messages to identical prefixes."""
 
 _HEX_ADDR = re.compile(r"0x[0-9a-fA-F]{4,}")
 _PID_REF = re.compile(r"\bpid[:= ]\s*\d+\b", re.IGNORECASE)
@@ -260,10 +265,15 @@ def build_normalised_event(
 def compute_fingerprint(symbol: str | None, message_prefix: str) -> str:
     """Stable identity hash for clustering and diff.
 
-    Symbol when present (high signal); otherwise normalised message prefix.
-    No hashing — readability beats compression here.
+    Hashed (sha256[:16]) so distinct messages with overlapping normalised
+    prefixes don't collide into the same cluster. Symbol when present (high
+    signal); otherwise normalised message prefix is the hash input.
+
+    The human-readable label lives in ``Cluster.symbol_or_prefix`` — the
+    fingerprint is purely an identity key.
     """
-    return f"sym:{symbol}" if symbol else f"msg:{message_prefix}"
+    key = f"sym:{symbol}" if symbol else f"msg:{message_prefix}"
+    return f"fp:{hashlib.sha256(key.encode()).hexdigest()[:16]}"
 
 
 def _timestamp_to_ms(ts: str) -> int:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
@@ -506,10 +506,13 @@ def format_diff(diff: dict) -> str:
     if drift:
         lines.append(f"Drift ({len(drift)}):")
         for entry in drift[:5]:
+            # inf delta (0 → N) renders as "new"; finite deltas keep the % suffix.
+            delta = entry["delta_pct"]
+            delta_str = "new" if delta == float("inf") else f"{delta:+.0f}%"
             lines.append(
                 f"  ~ {entry['symbol_or_prefix']}: "
                 f"{entry['max_duration_ms_a']:.0f} → {entry['max_duration_ms_b']:.0f}ms "
-                f"({entry['delta_pct']:+.0f}%)"
+                f"({delta_str})"
             )
     if stable:
         lines.append(f"Stable: {stable} cluster(s) unchanged")
@@ -583,10 +586,18 @@ def diff_sessions(
     stable = 0
     for key in shared_keys:
         ca, cb = a_map[key], b_map[key]
-        if ca.max_duration_ms == 0:
+        if ca.max_duration_ms == 0 and cb.max_duration_ms == 0:
+            stable += 1
             continue
-        delta_pct = (cb.max_duration_ms - ca.max_duration_ms) / ca.max_duration_ms * 100
-        if abs(delta_pct) >= drift_threshold_pct:
+        if ca.max_duration_ms == 0:
+            # 0 → N: a previously-silent cluster now hangs; treat as max worsening.
+            delta_pct: float = float("inf")
+        elif cb.max_duration_ms == 0:
+            # N → 0: cluster present in A but flat in B; fully improved.
+            delta_pct = -100.0
+        else:
+            delta_pct = (cb.max_duration_ms - ca.max_duration_ms) / ca.max_duration_ms * 100
+        if delta_pct == float("inf") or abs(delta_pct) >= drift_threshold_pct:
             drift.append(
                 {
                     "fingerprint": key,

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
@@ -198,6 +198,41 @@ class SessionStore:
         with open(path) as handle:
             return summary_from_json(json.load(handle))
 
+    def stash_auto_sample(self, session_id: str, fingerprint: str, sample: dict) -> None:
+        """Append an auto-sample record to ``<session>/auto_samples.jsonl``.
+
+        Append-only JSONL avoids the read-modify-write race that an aggregate
+        JSON dict would have under concurrent worker stashes. Readers reduce
+        last-write-wins per fingerprint.
+        """
+        path = self._auto_samples_path(session_id)
+        line = json.dumps({"fingerprint": fingerprint, "sample": sample}, separators=(",", ":"))
+        with open(path, "a") as handle:
+            handle.write(line + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def read_auto_samples(self, session_id: str) -> dict[str, dict]:
+        """Return ``{fingerprint: sample}`` with last-write-wins per fingerprint."""
+        path = self._auto_samples_path(session_id)
+        if not path.exists():
+            return {}
+        samples: dict[str, dict] = {}
+        with open(path) as handle:
+            for raw in handle:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                fingerprint = payload.get("fingerprint")
+                if fingerprint is None:
+                    continue
+                samples[fingerprint] = payload.get("sample")
+        return samples
+
     def read_events(self, session_id: str) -> list:
         """Read all events.jsonl lines, returning NormalisedEvent instances.
 
@@ -306,6 +341,9 @@ class SessionStore:
 
     def _summary_path(self, session_id: str) -> Path:
         return self.base_dir / session_id / "summary.json"
+
+    def _auto_samples_path(self, session_id: str) -> Path:
+        return self.base_dir / session_id / "auto_samples.jsonl"
 
     def _write_meta(self, meta: SessionMeta) -> None:
         path = self._meta_path(meta.session_id)

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
@@ -273,8 +273,59 @@ class SessionStore:
         """Worker writes here. Public so the worker can open it line-buffered."""
         return self._events_path(session_id)
 
+    def raw_path(self, session_id: str, gzipped: bool = False) -> Path:
+        """Raw-capture NDJSON path. ``gzipped=True`` returns the post-stop path."""
+        name = "raw.ndjson.gz" if gzipped else "raw.ndjson"
+        return self.base_dir / session_id / name
+
     def session_dir(self, session_id: str) -> Path:
         return self.base_dir / session_id
+
+    def session_total_bytes(self, session_id: str) -> int:
+        """Sum of all files under a session dir. Used by aggregate-cap pruning."""
+        total = 0
+        session_path = self.session_dir(session_id)
+        if not session_path.exists():
+            return 0
+        for path in session_path.rglob("*"):
+            if path.is_file():
+                with contextlib.suppress(OSError):
+                    total += path.stat().st_size
+        return total
+
+    def prune_to_aggregate_cap(self, max_bytes: int) -> int:
+        """Drop oldest sessions until total bytes ≤ max_bytes. Returns deletions.
+
+        Pairs with ``prune_expired``: TTL handles age, this handles disk usage
+        when activity outpaces TTL. Both are called automatically on every
+        ``create`` so the user never has to clean up manually.
+        """
+        if max_bytes <= 0:
+            return 0
+        # Oldest first — deletion order.
+        entries: list[tuple[int, str, int]] = []  # (started_at_ms, session_id, bytes)
+        total = 0
+        for entry in self.base_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                meta = self.load_meta(entry.name)
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+            size = self.session_total_bytes(entry.name)
+            total += size
+            entries.append((meta.started_at_ms, entry.name, size))
+        if total <= max_bytes:
+            return 0
+        entries.sort(key=lambda e: e[0])  # oldest first
+        deleted = 0
+        for _, session_id, size in entries:
+            if total <= max_bytes:
+                break
+            _remove_tree(self.session_dir(session_id))
+            total -= size
+            deleted += 1
+        return deleted
 
     def list_sessions(self) -> list[SessionMeta]:
         """All non-expired session metas, newest first."""

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_sessions.py
@@ -142,12 +142,13 @@ class SessionStore:
     def persist_worker_counters(self, session_id: str, counters: dict) -> None:
         """Worker calls this at shutdown to flush its line counters into meta.
 
-        Re-reads meta from disk so a concurrent ``stop()`` that already wrote
-        ``status=stopped`` is not clobbered back to ``running``.
+        Re-reads meta from disk so a concurrent terminal status — ``stopped``
+        from the parent's ``stop()`` or ``crashed`` from this worker's own
+        ``mark_crashed`` — is not clobbered back to ``running``.
         """
         meta = self.load_meta(session_id)
         meta.extras["line_counters"] = counters
-        if meta.status != _STATUS_STOPPED:
+        if meta.status not in (_STATUS_STOPPED, _STATUS_CRASHED):
             meta.status = _STATUS_RUNNING
         self._write_meta(meta)
 
@@ -163,12 +164,20 @@ class SessionStore:
         return meta
 
     def mark_crashed(self, session_id: str) -> None:
-        """Best-effort: tag a session whose worker exited without a summary."""
+        """Best-effort: tag a session whose worker exited without a summary.
+
+        Records ``stopped_at`` / ``stopped_at_ms`` so capture-duration math in
+        ``build_summary`` and ``--list-sessions`` reflects when the worker
+        actually died, not when the session was finally inspected.
+        """
         try:
             meta = self.load_meta(session_id)
         except FileNotFoundError:
             return
         meta.status = _STATUS_CRASHED
+        now = datetime.now()
+        meta.stopped_at = now.isoformat()
+        meta.stopped_at_ms = int(now.timestamp() * 1000)
         self._write_meta(meta)
 
     def signal_worker(self, session_id: str, sig: int = signal.SIGTERM) -> bool:
@@ -315,11 +324,17 @@ class SessionStore:
         extras: dict | None = None,
         top_n: int | None = None,
     ) -> SessionSummary:
-        """Convenience: read events.jsonl and run the pipeline through SummaryBuilder."""
+        """Convenience: read events.jsonl and run the pipeline through SummaryBuilder.
+
+        Duration prefers ``meta.stopped_at_ms`` (set on both ``stop()`` and
+        ``mark_crashed()``) so summaries for crashed/stopped sessions reflect
+        the actual capture window, not the time of inspection. Live sessions
+        without ``stopped_at_ms`` fall back to ``now`` as before.
+        """
         meta = self.load_meta(session_id)
         events = self.read_events(session_id)
-        now = datetime.now()
-        duration_ms = int(now.timestamp() * 1000) - meta.started_at_ms
+        end_ms = meta.stopped_at_ms or int(datetime.now().timestamp() * 1000)
+        duration_ms = end_ms - meta.started_at_ms
         builder = SummaryBuilder(
             session_id=session_id,
             started_at=meta.started_at,

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -144,7 +144,7 @@ class HangWatcher:
             True if stream ran without fatal errors.
         """
         resolved_udid = self._resolve_udid()
-        effective_predicate = _resolve_predicate(predicate, bundle_id)
+        effective_predicate = _resolve_predicate(predicate)
         cmd = self._build_stream_cmd(resolved_udid, effective_predicate)
 
         if verbose or not json_mode:
@@ -153,7 +153,7 @@ class HangWatcher:
                 file=sys.stderr,
             )
             if bundle_id:
-                print(f"Filter: {bundle_id}", file=sys.stderr)
+                print(f"Post-parse filter: {bundle_id}", file=sys.stderr)
             print(f"Predicate: {effective_predicate}", file=sys.stderr)
 
         self._register_signal_handler()
@@ -240,7 +240,7 @@ class HangWatcher:
             True if command ran without fatal errors.
         """
         resolved_udid = self._resolve_udid()
-        effective_predicate = _resolve_predicate(predicate, bundle_id)
+        effective_predicate = _resolve_predicate(predicate)
         start_timestamp = self._compute_start_timestamp(since_duration)
         cmd = self._build_show_cmd(resolved_udid, effective_predicate, start_timestamp)
 
@@ -372,9 +372,8 @@ class HangWatcher:
         return _pipeline_extract_duration_ms(message)
 
     def _matches_bundle(self, event: dict, bundle_id: str) -> bool:
-        """Check if event process name matches the bundle ID."""
-        app_name = bundle_id.rsplit(".", maxsplit=1)[-1].lower()
-        return app_name in event.get("process", "").lower()
+        """Delegate to module-level ``matches_bundle`` (kept for legacy callers)."""
+        return matches_bundle(event, bundle_id)
 
     def _format_event(self, event: dict) -> str:
         """Format a hang event for human-readable terminal output."""
@@ -406,14 +405,26 @@ class HangWatcher:
 # === HANGBUSTER (session mode) ===
 
 
-def _resolve_predicate(predicate: str | None, bundle_id: str | None) -> str:
-    """Resolution chain: CLI override → env var → default. Bundle filter ANDed in if set."""
-    base = predicate or os.getenv("IOS_SIM_HANG_PREDICATE") or DEFAULT_HANG_PREDICATE
-    if bundle_id:
-        app_name = bundle_id.rsplit(".", maxsplit=1)[-1]
-        bundle_clause = f'(processImagePath CONTAINS "/{app_name}.app/" OR process == "{app_name}")'
-        base = f"({base}) AND {bundle_clause}"
-    return base
+def _resolve_predicate(predicate: str | None) -> str:
+    """Resolution chain: CLI override → env var → default.
+
+    Bundle filtering is *not* applied here — see ``matches_bundle()``. The
+    default hang predicate matches events from RunningBoard, SpringBoard, and
+    the watchdog, none of which run inside the target app's process. ANDing a
+    ``process == <app>`` clause silently drops the bulk of useful hang signal.
+    """
+    return predicate or os.getenv("IOS_SIM_HANG_PREDICATE") or DEFAULT_HANG_PREDICATE
+
+
+def matches_bundle(event: dict, bundle_id: str) -> bool:
+    """Check if a parsed log event's process name matches the bundle ID.
+
+    Applied post-parse so hang events from system processes (RunningBoard,
+    SpringBoard) still flow through the pipeline; ``--bundle-id`` narrows the
+    final output rather than the os_log predicate.
+    """
+    app_name = bundle_id.rsplit(".", maxsplit=1)[-1].lower()
+    return app_name in event.get("process", "").lower()
 
 
 class HangBuster:
@@ -571,7 +582,7 @@ class HangBuster:
         predicate_override = args.get("predicate")
         auto_sample = bool(args.get("auto_sample", False))
         udid = args["udid"]
-        predicate = _resolve_predicate(predicate_override, bundle_id)
+        predicate = _resolve_predicate(predicate_override)
 
         events_path = self.store.events_path(session_id)
         counters = {"total": 0, "matched": 0, "dropped": 0}
@@ -628,6 +639,8 @@ class HangBuster:
                 last_event_at = time.time()
                 raw_event = _pipeline_parse_log_line(line.rstrip())
                 if raw_event is None:
+                    continue
+                if bundle_id and not matches_bundle(raw_event, bundle_id):
                     continue
                 counters["matched"] += 1
                 duration = raw_event.get("duration_ms")
@@ -801,7 +814,14 @@ Environment variables:
     _add_legacy_args(parser)
 
     # Filters / target
-    parser.add_argument("--bundle-id", help="Filter to a specific app bundle ID")
+    parser.add_argument(
+        "--bundle-id",
+        help=(
+            "Post-parse filter: drop events whose process name does not contain the "
+            "app suffix from this bundle ID. Hang capture itself stays simulator-global "
+            "(RunningBoard/SpringBoard events are kept)."
+        ),
+    )
     parser.add_argument("--predicate", help="Override the default os_log predicate")
     parser.add_argument("--udid", help="Device UDID (uses booted simulator if omitted)")
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -693,19 +693,13 @@ class HangBuster:
         except RuntimeError as error:
             raise RuntimeError(str(error)) from error
 
-    def _stash_auto_sample(self, session_id: str, normalised, sample: dict | None) -> None:
-        """Record an auto-sample side-channel for later cluster annotation."""
-        sample_path = self.store.session_dir(session_id) / "auto_samples.json"
-        existing = {}
-        if sample_path.exists():
-            try:
-                with open(sample_path) as handle:
-                    existing = json.load(handle)
-            except (OSError, json.JSONDecodeError):
-                existing = {}
-        existing[normalised.fingerprint] = sample
-        with open(sample_path, "w") as handle:
-            json.dump(existing, handle)
+    def _stash_auto_sample(self, session_id: str, normalised, sample: dict) -> None:
+        """Record an auto-sample side-channel for later cluster annotation.
+
+        Delegates to SessionStore's append-only JSONL writer — concurrent stashes
+        from a busy worker no longer race against each other.
+        """
+        self.store.stash_auto_sample(session_id, normalised.fingerprint, sample)
 
 
 def _attempt_auto_sample(pid: int) -> dict:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -77,6 +77,13 @@ DEFAULT_HANG_PREDICATE = (
     'OR ((eventMessage CONTAINS[c] "main thread") AND (eventMessage CONTAINS[c] "hang"))'
 )
 
+# How many times the worker re-spawns ``log stream`` after an EOF / subprocess
+# death before giving up and marking the session crashed. Override via env var
+# IOS_SIM_HANG_MAX_RESTARTS.
+DEFAULT_MAX_STREAM_RESTARTS = 3
+# Backoff between restart attempts. Short — log stream usually recovers fast.
+RESTART_BACKOFF_SECONDS = 2.0
+
 
 def _compute_start_timestamp(duration_str: str) -> str:
     """Parse duration string and return ISO-8601 start timestamp.
@@ -541,8 +548,16 @@ class HangBuster:
         lines = [f"Sessions: {len(metas)}"]
         for meta in metas[:20]:
             stopped = meta.stopped_at or "-"
+            counters = meta.extras.get("line_counters", {})
+            restarts = counters.get("stream_restarts", 0)
+            duration_s = (
+                (meta.stopped_at_ms - meta.started_at_ms) / 1000.0 if meta.stopped_at_ms else None
+            )
+            duration_str = f"  capture={duration_s:.1f}s" if duration_s is not None else ""
+            restart_str = f"  restarts={restarts}" if restarts else ""
             lines.append(
-                f"  {meta.session_id}  {meta.status:8s}  started={meta.started_at}  stopped={stopped}"
+                f"  {meta.session_id}  {meta.status:8s}  started={meta.started_at}  "
+                f"stopped={stopped}{duration_str}{restart_str}"
             )
         if len(metas) > 20:
             lines.append(f"  ... {len(metas) - 20} more")
@@ -572,8 +587,11 @@ class HangBuster:
         """Long-running worker entrypoint. Returns exit code.
 
         Layout: claim meta → resolve predicate → open events.jsonl line-buffered
-        → spawn ``xcrun simctl spawn ... log stream`` → loop with select-based
-        readline timeout. SIGTERM flushes and exits cleanly.
+        → for each restart attempt, spawn ``xcrun simctl spawn ... log stream``
+        and read lines until EOF or subprocess death. SIGTERM flushes and exits
+        cleanly. EOF / subprocess death triggers a bounded restart loop
+        (``IOS_SIM_HANG_MAX_RESTARTS``); on exhaustion the session is marked
+        ``crashed`` rather than left in stale ``running`` state.
         """
         meta = self.store.claim_worker(session_id, pid=os.getpid())
         args = meta.args
@@ -583,9 +601,10 @@ class HangBuster:
         auto_sample = bool(args.get("auto_sample", False))
         udid = args["udid"]
         predicate = _resolve_predicate(predicate_override)
+        max_restarts = env_int("IOS_SIM_HANG_MAX_RESTARTS", DEFAULT_MAX_STREAM_RESTARTS)
 
         events_path = self.store.events_path(session_id)
-        counters = {"total": 0, "matched": 0, "dropped": 0}
+        counters = {"total": 0, "matched": 0, "dropped": 0, "stream_restarts": 0}
         sampled_fingerprints: set[str] = set()
         stop_flag = {"value": False}
 
@@ -596,8 +615,9 @@ class HangBuster:
         signal.signal(signal.SIGINT, _on_sigterm)
 
         cmd = ["xcrun", "simctl", "spawn", udid, "log", "stream", "--predicate", predicate]
-        try:
-            proc = subprocess.Popen(
+
+        def _spawn_log_stream() -> subprocess.Popen:
+            return subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
@@ -605,78 +625,164 @@ class HangBuster:
                 text=True,
                 bufsize=1,
             )
-        except FileNotFoundError:
-            self.store.mark_crashed(session_id)
-            return 2
 
-        last_fsync = time.time()
-        last_event_at = time.time()
-        stream_silence_seconds = 30.0
+        proc: subprocess.Popen | None = None
+        crashed = False
+        try:
+            with open(events_path, "a", buffering=1) as out_handle:
+                for attempt in range(max_restarts + 1):
+                    if stop_flag["value"]:
+                        break
+                    if attempt > 0:
+                        counters["stream_restarts"] = attempt
+                        out_handle.write(
+                            json.dumps(
+                                {
+                                    "event": "stream_restart",
+                                    "attempt": attempt,
+                                    "at_ms": int(time.time() * 1000),
+                                }
+                            )
+                            + "\n"
+                        )
+                        out_handle.flush()
+                        time.sleep(RESTART_BACKOFF_SECONDS)
+                        if stop_flag["value"]:
+                            break
+                    try:
+                        proc = _spawn_log_stream()
+                    except FileNotFoundError:
+                        crashed = True
+                        break
 
-        with open(events_path, "a", buffering=1) as out_handle:
-            while not stop_flag["value"]:
-                if proc.stdout is None:
-                    break
-                ready, _, _ = select.select([proc.stdout], [], [], 0.25)
-                if not ready:
-                    # No data this tick — check for stream silence + writer fsync.
-                    if time.time() - last_event_at > stream_silence_seconds:
+                    exit_code = self._read_stream_into_events(
+                        proc=proc,
+                        out_handle=out_handle,
+                        stop_flag=stop_flag,
+                        counters=counters,
+                        bundle_id=bundle_id,
+                        min_hang_ms=min_hang_ms,
+                        auto_sample=auto_sample,
+                        sampled_fingerprints=sampled_fingerprints,
+                        session_id=session_id,
+                        session_start_ms=meta.started_at_ms,
+                    )
+
+                    if stop_flag["value"]:
+                        # Clean SIGTERM. Don't restart, don't mark crashed.
                         out_handle.write(
                             json.dumps({"event": "stream_ended", "at_ms": int(time.time() * 1000)})
                             + "\n"
                         )
                         out_handle.flush()
                         break
-                    if time.time() - last_fsync > 1.0:
-                        out_handle.flush()
-                        os.fsync(out_handle.fileno())
-                        last_fsync = time.time()
-                    continue
-                line = proc.stdout.readline()
-                if not line:
-                    break
-                counters["total"] += 1
-                last_event_at = time.time()
-                raw_event = _pipeline_parse_log_line(line.rstrip())
-                if raw_event is None:
-                    continue
-                if bundle_id and not matches_bundle(raw_event, bundle_id):
-                    continue
-                counters["matched"] += 1
-                duration = raw_event.get("duration_ms")
-                if duration is None or duration < min_hang_ms:
-                    counters["dropped"] += 1
-                    continue
-                normalised = build_normalised_event(
-                    raw_event,
-                    session_start_ms=meta.started_at_ms,
-                    current_ms=int(time.time() * 1000),
-                )
-                if normalised is None:
-                    continue
-                if auto_sample and normalised.fingerprint not in sampled_fingerprints:
-                    sampled_fingerprints.add(normalised.fingerprint)
-                    self._stash_auto_sample(
-                        session_id, normalised, _attempt_auto_sample(normalised.pid)
+
+                    # Subprocess died without a stop request. Record it.
+                    out_handle.write(
+                        json.dumps(
+                            {
+                                "event": "stream_died",
+                                "exit_code": exit_code,
+                                "attempt": attempt,
+                                "at_ms": int(time.time() * 1000),
+                            }
+                        )
+                        + "\n"
                     )
-                out_handle.write(event_to_jsonl(normalised) + "\n")
+                    out_handle.flush()
+                else:
+                    # for/else: ran every restart without a clean break — exhausted.
+                    crashed = True
 
-            # Drain on shutdown — flush any pending lines + cleanup subprocess.
-            out_handle.flush()
-            with contextlib.suppress(OSError):
-                os.fsync(out_handle.fileno())
+                with contextlib.suppress(OSError):
+                    os.fsync(out_handle.fileno())
+        finally:
+            if proc is not None and proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
 
-        if proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                proc.kill()
+            if crashed and not stop_flag["value"]:
+                self.store.mark_crashed(session_id)
+            # SessionStore.persist_worker_counters preserves terminal status
+            # (stopped from parent's stop(), or crashed above) and avoids
+            # clobbering it back to running.
+            self.store.persist_worker_counters(session_id, counters)
 
-        # Flush line counters; SessionStore preserves status=stopped if the parent's
-        # stop() already raced ahead, otherwise marks status=running.
-        self.store.persist_worker_counters(session_id, counters)
-        return 0
+        return 2 if crashed else 0
+
+    def _read_stream_into_events(
+        self,
+        *,
+        proc: subprocess.Popen,
+        out_handle,
+        stop_flag: dict,
+        counters: dict,
+        bundle_id: str | None,
+        min_hang_ms: int,
+        auto_sample: bool,
+        sampled_fingerprints: set[str],
+        session_id: str,
+        session_start_ms: int,
+    ) -> int | None:
+        """Read lines until EOF / subprocess death / stop request.
+
+        Returns the subprocess exit code (None if still alive when stop_flag
+        was set, otherwise the recorded poll() value at exit time). Does not
+        emit ``stream_died`` / ``stream_ended`` events itself — the caller
+        decides which marker to write based on stop_flag.
+        """
+        last_fsync = time.time()
+        while not stop_flag["value"]:
+            if proc.stdout is None:
+                return proc.poll()
+            ready, _, _ = select.select([proc.stdout], [], [], 0.25)
+            if not ready:
+                if time.time() - last_fsync > 1.0:
+                    out_handle.flush()
+                    with contextlib.suppress(OSError):
+                        os.fsync(out_handle.fileno())
+                    last_fsync = time.time()
+                # If the subprocess silently died, poll() returns its code now.
+                # Otherwise keep waiting — quiet log streams are normal.
+                exit_code = proc.poll()
+                if exit_code is not None:
+                    return exit_code
+                continue
+            line = proc.stdout.readline()
+            if not line:
+                # EOF — subprocess closed stdout. Wait briefly for poll() to
+                # settle so we report a meaningful exit code.
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=0.5)
+                return proc.poll()
+            counters["total"] += 1
+            raw_event = _pipeline_parse_log_line(line.rstrip())
+            if raw_event is None:
+                continue
+            if bundle_id and not matches_bundle(raw_event, bundle_id):
+                continue
+            counters["matched"] += 1
+            duration = raw_event.get("duration_ms")
+            if duration is None or duration < min_hang_ms:
+                counters["dropped"] += 1
+                continue
+            normalised = build_normalised_event(
+                raw_event,
+                session_start_ms=session_start_ms,
+                current_ms=int(time.time() * 1000),
+            )
+            if normalised is None:
+                continue
+            if auto_sample and normalised.fingerprint not in sampled_fingerprints:
+                sampled_fingerprints.add(normalised.fingerprint)
+                self._stash_auto_sample(
+                    session_id, normalised, _attempt_auto_sample(normalised.pid)
+                )
+            out_handle.write(event_to_jsonl(normalised) + "\n")
+        return proc.poll()
 
     # === PRIVATE ===
 

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -449,6 +449,9 @@ class HangBuster:
     def start(self, args: dict, udid: str | None) -> str:
         """Create session, detach worker, return session_id once worker registers."""
         self.store.prune_expired()
+        aggregate_cap_mb = env_int("IOS_SIM_HANG_TOTAL_CAP_MB", 100)
+        if aggregate_cap_mb > 0:
+            self.store.prune_to_aggregate_cap(aggregate_cap_mb * 1024 * 1024)
         resolved_udid = self._resolve_udid(udid)
         meta = self.store.create({**args, "udid": resolved_udid})
         cmd = [
@@ -489,6 +492,11 @@ class HangBuster:
             self._wait_for_worker_exit(session_id, timeout_seconds=2.0)
         meta = self.store.load_meta(session_id)
         line_counters = meta.extras.get("line_counters", {})
+
+        if meta.args.get("raw_capture"):
+            # Raw-capture sessions skip the clustering pipeline entirely.
+            return self._stop_raw_session(session_id, meta, line_counters, json_mode)
+
         summary = self.store.build_summary(
             session_id,
             matched_lines=line_counters.get("matched", 0),
@@ -506,6 +514,63 @@ class HangBuster:
         budget = budget_tokens or env_int("IOS_SIM_HANG_BUDGET_TOKENS", 0) or None
         return compress_to_budget(summary, max_tokens=budget, default_top_n=effective_top_n)
 
+    def _stop_raw_session(self, session_id: str, meta, line_counters: dict, json_mode: bool) -> str:
+        """Finalise a raw-capture session: gzip raw.ndjson, write status, report.
+
+        No summary.json is written for raw sessions — clustering is not applied.
+        ``--get-details`` redirects to the raw file.
+        """
+        import gzip
+        import shutil
+
+        raw_path = self.store.raw_path(session_id)
+        gz_path = self.store.raw_path(session_id, gzipped=True)
+        raw_bytes = raw_path.stat().st_size if raw_path.exists() else 0
+        no_gzip = bool(meta.args.get("no_gzip"))
+        final_path = raw_path
+        if not no_gzip and raw_path.exists() and raw_bytes > 0:
+            with open(raw_path, "rb") as src, gzip.open(gz_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            raw_path.unlink()
+            final_path = gz_path
+            meta.extras["raw_gzipped"] = True
+            meta.extras["raw_bytes_compressed"] = gz_path.stat().st_size
+
+        meta.extras["raw_bytes"] = raw_bytes
+        # Mark stopped without going through build_summary (no summary.json for raw).
+        meta.status = "stopped"
+        from datetime import datetime as _dt
+
+        now = _dt.now()
+        meta.stopped_at = now.isoformat()
+        meta.stopped_at_ms = int(now.timestamp() * 1000)
+        self.store._write_meta(meta)
+        truncated = bool(meta.extras.get("truncated"))
+        if json_mode:
+            return json.dumps(
+                {
+                    "session_id": session_id,
+                    "mode": "raw",
+                    "raw_path": str(final_path),
+                    "raw_bytes": raw_bytes,
+                    "raw_bytes_compressed": meta.extras.get("raw_bytes_compressed"),
+                    "truncated": truncated,
+                    "total_lines": line_counters.get("total", 0),
+                    "stream_restarts": line_counters.get("stream_restarts", 0),
+                },
+                indent=2,
+            )
+        size_mb = raw_bytes / (1024 * 1024)
+        gz_mb = (meta.extras.get("raw_bytes_compressed") or 0) / (1024 * 1024)
+        trunc_str = " [TRUNCATED at size cap]" if truncated else ""
+        gz_str = f" → {gz_mb:.2f} MB gzipped" if gz_path.exists() else ""
+        explore_cmd = "zcat" if gz_path.exists() else "cat"
+        return (
+            f"Session {session_id}: raw mode, {line_counters.get('total', 0)} lines, "
+            f"{size_mb:.2f} MB{gz_str}{trunc_str}\n"
+            f"Explore: {explore_cmd} {final_path} | jq ..."
+        )
+
     def get_details(
         self,
         session_id: str,
@@ -515,6 +580,17 @@ class HangBuster:
         json_mode: bool = False,
     ) -> str:
         """Drill into a stored session. ``cluster`` is 1-indexed for human use."""
+        try:
+            meta = self.store.load_meta(session_id)
+        except FileNotFoundError:
+            return f"Unknown session: {session_id}"
+        if meta.args.get("raw_capture"):
+            # Raw sessions have no clusters — point at the file.
+            gz_path = self.store.raw_path(session_id, gzipped=True)
+            ndjson_path = self.store.raw_path(session_id)
+            target = gz_path if gz_path.exists() else ndjson_path
+            cmd = "zcat" if gz_path.exists() else "cat"
+            return f"Raw session — explore with: {cmd} {target} | jq ..."
         summary = self.store.load_summary(session_id)
         if summary is None:
             return f"No summary for {session_id}. Run --stop first."
@@ -555,9 +631,14 @@ class HangBuster:
             )
             duration_str = f"  capture={duration_s:.1f}s" if duration_s is not None else ""
             restart_str = f"  restarts={restarts}" if restarts else ""
+            raw_str = ""
+            if meta.args.get("raw_capture"):
+                size = meta.extras.get("raw_bytes_compressed") or meta.extras.get("raw_bytes") or 0
+                trunc = "T" if meta.extras.get("truncated") else "-"
+                raw_str = f"  raw={size / 1024 / 1024:.2f}MB(trunc:{trunc})"
             lines.append(
                 f"  {meta.session_id}  {meta.status:8s}  started={meta.started_at}  "
-                f"stopped={stopped}{duration_str}{restart_str}"
+                f"stopped={stopped}{duration_str}{restart_str}{raw_str}"
             )
         if len(metas) > 20:
             lines.append(f"  ... {len(metas) - 20} more")
@@ -592,6 +673,11 @@ class HangBuster:
         cleanly. EOF / subprocess death triggers a bounded restart loop
         (``IOS_SIM_HANG_MAX_RESTARTS``); on exhaustion the session is marked
         ``crashed`` rather than left in stale ``running`` state.
+
+        In ``--raw-capture`` mode the worker spawns ``log stream --style ndjson``
+        and dumps raw lines to ``raw.ndjson`` instead of parsing into the
+        clustering pipeline. Same restart/crash semantics; additional size-cap
+        bail when the raw file exceeds ``max_size_mb``.
         """
         meta = self.store.claim_worker(session_id, pid=os.getpid())
         args = meta.args
@@ -602,11 +688,14 @@ class HangBuster:
         udid = args["udid"]
         predicate = _resolve_predicate(predicate_override)
         max_restarts = env_int("IOS_SIM_HANG_MAX_RESTARTS", DEFAULT_MAX_STREAM_RESTARTS)
+        raw_capture = bool(args.get("raw_capture", False))
+        max_size_bytes = int(args.get("max_size_mb", 10)) * 1024 * 1024 if raw_capture else 0
 
         events_path = self.store.events_path(session_id)
         counters = {"total": 0, "matched": 0, "dropped": 0, "stream_restarts": 0}
         sampled_fingerprints: set[str] = set()
         stop_flag = {"value": False}
+        cap_state = {"hit": False}  # set by raw reader when size cap exceeded
 
         def _on_sigterm(_signum, _frame):
             stop_flag["value"] = True
@@ -615,6 +704,8 @@ class HangBuster:
         signal.signal(signal.SIGINT, _on_sigterm)
 
         cmd = ["xcrun", "simctl", "spawn", udid, "log", "stream", "--predicate", predicate]
+        if raw_capture:
+            cmd.extend(["--style", "ndjson"])
 
         def _spawn_log_stream() -> subprocess.Popen:
             return subprocess.Popen(
@@ -629,7 +720,13 @@ class HangBuster:
         proc: subprocess.Popen | None = None
         crashed = False
         try:
-            with open(events_path, "a", buffering=1) as out_handle:
+            with contextlib.ExitStack() as stack:
+                out_handle = stack.enter_context(open(events_path, "a", buffering=1))
+                raw_handle = (
+                    stack.enter_context(open(self.store.raw_path(session_id), "a", buffering=1))
+                    if raw_capture
+                    else None
+                )
                 for attempt in range(max_restarts + 1):
                     if stop_flag["value"]:
                         break
@@ -655,18 +752,45 @@ class HangBuster:
                         crashed = True
                         break
 
-                    exit_code = self._read_stream_into_events(
-                        proc=proc,
-                        out_handle=out_handle,
-                        stop_flag=stop_flag,
-                        counters=counters,
-                        bundle_id=bundle_id,
-                        min_hang_ms=min_hang_ms,
-                        auto_sample=auto_sample,
-                        sampled_fingerprints=sampled_fingerprints,
-                        session_id=session_id,
-                        session_start_ms=meta.started_at_ms,
-                    )
+                    if raw_capture:
+                        exit_code = self._read_stream_into_raw(
+                            proc=proc,
+                            raw_handle=raw_handle,
+                            stop_flag=stop_flag,
+                            counters=counters,
+                            max_size_bytes=max_size_bytes,
+                            session_id=session_id,
+                            cap_state=cap_state,
+                        )
+                    else:
+                        exit_code = self._read_stream_into_events(
+                            proc=proc,
+                            out_handle=out_handle,
+                            stop_flag=stop_flag,
+                            counters=counters,
+                            bundle_id=bundle_id,
+                            min_hang_ms=min_hang_ms,
+                            auto_sample=auto_sample,
+                            sampled_fingerprints=sampled_fingerprints,
+                            session_id=session_id,
+                            session_start_ms=meta.started_at_ms,
+                        )
+
+                    if cap_state["hit"]:
+                        # Size-cap is a clean stop, not a crash. Record marker.
+                        out_handle.write(
+                            json.dumps(
+                                {
+                                    "event": "size_cap_hit",
+                                    "bytes": self.store.raw_path(session_id).stat().st_size,
+                                    "at_ms": int(time.time() * 1000),
+                                }
+                            )
+                            + "\n"
+                        )
+                        out_handle.flush()
+                        self._mark_truncated(session_id)
+                        break
 
                     if stop_flag["value"]:
                         # Clean SIGTERM. Don't restart, don't mark crashed.
@@ -697,6 +821,7 @@ class HangBuster:
                 with contextlib.suppress(OSError):
                     os.fsync(out_handle.fileno())
         finally:
+            # raw_handle / out_handle are closed by ExitStack on with-block exit.
             if proc is not None and proc.poll() is None:
                 proc.terminate()
                 try:
@@ -712,6 +837,72 @@ class HangBuster:
             self.store.persist_worker_counters(session_id, counters)
 
         return 2 if crashed else 0
+
+    def _read_stream_into_raw(
+        self,
+        *,
+        proc: subprocess.Popen,
+        raw_handle,
+        stop_flag: dict,
+        counters: dict,
+        max_size_bytes: int,
+        session_id: str,
+        cap_state: dict,
+    ) -> int | None:
+        """Raw NDJSON capture: dump lines verbatim to raw.ndjson, no parsing.
+
+        Sets ``cap_state['hit'] = True`` and returns when the file exceeds
+        ``max_size_bytes``. The caller treats that as a clean stop (no
+        restart, no crash) and writes a ``size_cap_hit`` marker.
+        """
+        raw_path = self.store.raw_path(session_id)
+        bytes_written = raw_path.stat().st_size if raw_path.exists() else 0
+        last_fsync = time.time()
+        while not stop_flag["value"]:
+            if proc.stdout is None:
+                return proc.poll()
+            ready, _, _ = select.select([proc.stdout], [], [], 0.25)
+            if not ready:
+                if time.time() - last_fsync > 1.0:
+                    raw_handle.flush()
+                    with contextlib.suppress(OSError):
+                        os.fsync(raw_handle.fileno())
+                    last_fsync = time.time()
+                exit_code = proc.poll()
+                if exit_code is not None:
+                    return exit_code
+                continue
+            line = proc.stdout.readline()
+            if not line:
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=0.5)
+                return proc.poll()
+            counters["total"] += 1
+            # Drop non-JSON banners like `log stream`'s "Filtering the log data..." and
+            # any pwuid warnings. Raw consumers expect strict NDJSON.
+            stripped = line.lstrip()
+            if not stripped.startswith("{"):
+                continue
+            raw_handle.write(line if line.endswith("\n") else line + "\n")
+            bytes_written += len(line) + (0 if line.endswith("\n") else 1)
+            if max_size_bytes > 0 and bytes_written >= max_size_bytes:
+                cap_state["hit"] = True
+                raw_handle.flush()
+                with contextlib.suppress(OSError):
+                    os.fsync(raw_handle.fileno())
+                return proc.poll()
+        return proc.poll()
+
+    def _mark_truncated(self, session_id: str) -> None:
+        """Best-effort: set extras.truncated=True. Called when size cap hit."""
+        try:
+            meta = self.store.load_meta(session_id)
+        except FileNotFoundError:
+            return
+        meta.extras["truncated"] = True
+        # Write meta directly via the public store path; intentional: SessionStore
+        # exposes no extras setter and we want one round-trip not two.
+        self.store._write_meta(meta)
 
     def _read_stream_into_events(
         self,
@@ -966,6 +1157,27 @@ Environment variables:
     )
     parser.add_argument("--terse", action="store_true", help="--stop: force L0 one-line output")
 
+    # Raw capture (HangBuster)
+    parser.add_argument(
+        "--raw-capture",
+        action="store_true",
+        help=(
+            "With --start: capture raw os_log NDJSON to raw.ndjson instead of bucketed events. "
+            "Explore afterwards with: zcat <session>/raw.ndjson.gz | jq ..."
+        ),
+    )
+    parser.add_argument(
+        "--max-size-mb",
+        type=int,
+        default=10,
+        help="Raw-capture per-session size cap in MB (default 10). Worker stops at cap.",
+    )
+    parser.add_argument(
+        "--no-gzip",
+        action="store_true",
+        help="Skip gzip of raw.ndjson on --stop (raw-capture mode only).",
+    )
+
     # Output
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
     parser.add_argument("--verbose", action="store_true", help="Include raw lines (legacy modes)")
@@ -989,6 +1201,9 @@ Environment variables:
             "bundle_id": args.bundle_id,
             "predicate": args.predicate,
             "auto_sample": args.auto_sample,
+            "raw_capture": args.raw_capture,
+            "max_size_mb": args.max_size_mb,
+            "no_gzip": args.no_gzip,
         }
         try:
             session_id = buster.start(start_args, udid=args.udid)

--- a/tests/fixtures/sample_session.py
+++ b/tests/fixtures/sample_session.py
@@ -19,50 +19,62 @@ from common.hang_pipeline import (
 def make_events(count: int = 50, duration_window_ms: int = 30_000) -> list[NormalisedEvent]:
     """Produce ``count`` synthetic events spread over ``duration_window_ms``.
 
-    Distribution: ~10 unique fingerprints, biased toward a few hot clusters so
-    output stays compact under the token-budget contract.
+    Mixes all four Severity tiers, ≥10 unique fingerprints, two processes, and
+    a temporal burst + quiet gap so SummaryBuilder's aggregators have content
+    to surface. Stress-shape rather than soft-shape so the token-budget tests
+    actually exercise the formatter.
     """
-    events: list[NormalisedEvent] = []
-    symbols = [
-        "[ImageDecoder decode:]",
-        "[NetworkSession fetch:]",
-        "MainViewModel.refresh()",
-        "[FileCache flush]",
-        "RunningBoard watchdog",
-        "[Layout calculateBounds]",
-        "[Database query:]",
-        "AnimationCoordinator.tick",
-        "[AudioEngine render]",
-        "[Notification post]",
+    # (symbol, base_duration_ms, severity_band, process) — long symbol prefixes for stress.
+    specs = [
+        ("[ImageDecoderForLargeRasterAssets decodeWithOptions:]", 1100, "critical", "MyApp"),
+        ("[NetworkSession.background fetchUpstreamPayload:]", 900, "critical", "MyApp"),
+        ("MainViewModel.refreshFromRemoteSource(timeout:)", 700, "critical", "MyApp"),
+        ("[FileCache flushAllDirtyPagesToDisk]", 380, "warn", "MyApp"),
+        ("RunningBoard watchdog: assertion expired", 350, "warn", "MyApp"),
+        ("[Layout calculateBoundsInsideContainer:withConstraints:]", 310, "warn", "MyApp"),
+        ("[Database executeUnboundedQuery:onConnection:]", 180, "minor", "MyApp"),
+        ("AnimationCoordinator.tickWithDisplayLinkFrame", 150, "minor", "Helper"),
+        ("[AudioEngine renderQuantum:withInterruptions:]", 120, "minor", "Helper"),
+        ("[Notification postOnDistributedCenter:]", 100, "minor", "Helper"),
+        ("MainThreadDispatch.semaphoreWaitLongerThanForever()", 2800, "frozen", "MyApp"),
+        ("[DiskArbitration mountAllRetrying:]", 3200, "frozen", "Helper"),
     ]
-    # Hot clusters: first 3 symbols get most of the volume.
-    hot_share = [22, 12, 8]  # 42 events across hot clusters
-    cold_share = [1] * (count - sum(hot_share))  # remaining spread across cold clusters
-    shares = hot_share + cold_share
+    # Per-cluster event counts — first cluster is hot (drives near-max count).
+    counts = [18, 6, 4, 5, 4, 3, 3, 2, 2, 1, 1, 1]
     delta_step = duration_window_ms // count
-    for i, share_idx in enumerate(_flatten_share(shares)):
-        symbol = symbols[share_idx % len(symbols)]
-        # Hot clusters get higher durations.
-        duration = 600 + (share_idx * 80) + (i % 5) * 20
-        events.append(
-            NormalisedEvent(
-                delta_ms=delta_step * i,
-                process="MyApp",
-                pid=4242,
-                duration_ms=duration,
-                severity=bucket_severity(duration),
-                symbol=symbol,
-                message_prefix=f"hang in {symbol}",
-                fingerprint=compute_fingerprint(symbol, f"hang in {symbol}"),
-                raw_message=f"Hang detected: {duration}ms in {symbol}",
+    events: list[NormalisedEvent] = []
+    event_idx = 0
+    for spec_idx, ((symbol, base_dur, _band, process), per_cluster) in enumerate(
+        zip(specs, counts, strict=True)
+    ):
+        for j in range(per_cluster):
+            # Pack the first cluster temporally close to trigger detect_temporal_bursts.
+            if spec_idx == 0:
+                delta = j * 120  # 18 events inside a 2.1s window
+            else:
+                # Other clusters spread across the window with a deliberate quiet gap
+                # in the middle for detect_quiet_periods to pick up.
+                delta = delta_step * event_idx
+                if delta_step * event_idx > duration_window_ms // 2:
+                    delta += 7000  # 7s gap → triggers quiet_period detection
+            duration = base_dur + (j % 4) * 25
+            events.append(
+                NormalisedEvent(
+                    delta_ms=delta,
+                    process=process,
+                    pid=4242 if process == "MyApp" else 5151,
+                    duration_ms=duration,
+                    severity=bucket_severity(duration),
+                    symbol=symbol,
+                    message_prefix=f"hang in {symbol}",
+                    fingerprint=compute_fingerprint(symbol, f"hang in {symbol}"),
+                    raw_message=f"Hang detected: {duration}ms in {symbol}",
+                )
             )
-        )
+            event_idx += 1
+            if event_idx >= count:
+                return events
     return events
-
-
-def _flatten_share(shares: list[int]) -> list[int]:
-    """Convert per-bucket counts into a flat index list."""
-    return [idx for idx, count in enumerate(shares) for _ in range(count)]
 
 
 def make_summary(

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -58,9 +58,8 @@ def test_diff_detects_new_critical_cluster():
 def test_diff_detects_resolved_cluster():
     a = make_summary(session_id="hang-a")
     # B has fewer fingerprints than A — at least one resolved.
-    b_events = [
-        e for e in make_events() if e.symbol != "[ImageDecoder decode:]"
-    ]
+    dropped_symbol = "[ImageDecoderForLargeRasterAssets decodeWithOptions:]"
+    b_events = [e for e in make_events() if e.symbol != dropped_symbol]
     b = SummaryBuilder(
         session_id="hang-b",
         started_at="2026-05-22T14:35:00",
@@ -68,7 +67,7 @@ def test_diff_detects_resolved_cluster():
     ).build(b_events)
     result = diff_sessions(a, b)
     assert any(
-        c["symbol_or_prefix"] == "[ImageDecoder decode:]" for c in result["resolved_clusters"]
+        c["symbol_or_prefix"] == dropped_symbol for c in result["resolved_clusters"]
     )
 
 
@@ -133,59 +132,62 @@ def test_format_diff_version_mismatch_carries_warning():
     assert "mismatch" in out.lower()
 
 
-# === zero-duration drift handling (#79) ===
+# === shared helper for SessionSummary fabrication ===
 
 
-def _zero_dur_summary(session_id: str, clusters: dict[str, float]) -> "SessionSummary":
-    """Build a SessionSummary with a controlled fingerprint → max_duration_ms map."""
+def _summary_with_clusters(session_id: str, clusters_spec: list[tuple[str, float, str]]):
+    """Build a SessionSummary from (fingerprint, max_dur, severity) tuples."""
     from common.hang_pipeline import Cluster, NormalisedEvent, SessionSummary, Severity
 
-    cluster_list = [
+    clusters = [
         Cluster(
             fingerprint=fp,
             count=1,
             max_duration_ms=max_dur,
             total_duration_ms=max_dur,
             first_delta_ms=0,
-            severity=Severity.CRITICAL if max_dur >= 500 else Severity.MINOR,
+            severity=Severity(sev),
             symbol_or_prefix=fp,
             sample_event=NormalisedEvent(
                 delta_ms=0,
                 process="p",
                 pid=1,
                 duration_ms=max_dur,
-                severity=Severity.CRITICAL if max_dur >= 500 else Severity.MINOR,
+                severity=Severity(sev),
                 symbol=fp,
                 message_prefix=fp,
                 fingerprint=fp,
             ),
         )
-        for fp, max_dur in clusters.items()
+        for fp, max_dur, sev in clusters_spec
     ]
     return SessionSummary(
         session_id=session_id,
         started_at="t",
         duration_ms=1000,
-        event_count=len(cluster_list),
+        event_count=len(clusters),
         dropped_below_threshold=0,
-        matched_lines=len(cluster_list),
-        total_lines=len(cluster_list),
-        clusters=cluster_list,
+        matched_lines=len(clusters),
+        total_lines=len(clusters),
+        clusters=clusters,
         aggregates={},
     )
 
 
+# === zero-duration drift handling (#79) ===
+
+
 def test_diff_zero_to_zero_counts_as_stable():
-    a = _zero_dur_summary("hang-a", {"fp:silent": 0.0})
-    b = _zero_dur_summary("hang-b", {"fp:silent": 0.0})
+    a = _summary_with_clusters("hang-a", [("fp:silent", 0.0, "minor")])
+    b = _summary_with_clusters("hang-b", [("fp:silent", 0.0, "minor")])
     result = diff_sessions(a, b)
     assert result["stable_count"] == 1
     assert not result["drift"]
 
 
 def test_diff_zero_to_nonzero_is_drift_with_inf_delta():
-    a = _zero_dur_summary("hang-a", {"fp:newsignal": 0.0})
-    b = _zero_dur_summary("hang-b", {"fp:newsignal": 800.0})
+    a = _summary_with_clusters("hang-a", [("fp:newsignal", 0.0, "minor")])
+    b = _summary_with_clusters("hang-b", [("fp:newsignal", 800.0, "critical")])
     result = diff_sessions(a, b)
     assert len(result["drift"]) == 1
     assert result["drift"][0]["delta_pct"] == float("inf")
@@ -194,8 +196,8 @@ def test_diff_zero_to_nonzero_is_drift_with_inf_delta():
 
 
 def test_diff_nonzero_to_zero_is_drift_with_minus_one_hundred():
-    a = _zero_dur_summary("hang-a", {"fp:fixed": 800.0})
-    b = _zero_dur_summary("hang-b", {"fp:fixed": 0.0})
+    a = _summary_with_clusters("hang-a", [("fp:fixed", 800.0, "critical")])
+    b = _summary_with_clusters("hang-b", [("fp:fixed", 0.0, "minor")])
     result = diff_sessions(a, b)
     assert len(result["drift"]) == 1
     assert result["drift"][0]["delta_pct"] == -100.0
@@ -203,16 +205,73 @@ def test_diff_nonzero_to_zero_is_drift_with_minus_one_hundred():
 
 def test_diff_nonzero_unchanged_still_uses_threshold():
     # Regression guard — the new zero-handling branches must not break the standard path.
-    a = _zero_dur_summary("hang-a", {"fp:steady": 500.0})
-    b = _zero_dur_summary("hang-b", {"fp:steady": 505.0})  # 1% drift, well under 20% threshold
+    a = _summary_with_clusters("hang-a", [("fp:steady", 500.0, "critical")])
+    b = _summary_with_clusters("hang-b", [("fp:steady", 505.0, "critical")])  # 1% drift
     result = diff_sessions(a, b)
     assert result["stable_count"] == 1
     assert not result["drift"]
 
 
 def test_format_diff_renders_inf_delta_as_new():
-    a = _zero_dur_summary("hang-a", {"fp:newsignal": 0.0})
-    b = _zero_dur_summary("hang-b", {"fp:newsignal": 800.0})
+    a = _summary_with_clusters("hang-a", [("fp:newsignal", 0.0, "minor")])
+    b = _summary_with_clusters("hang-b", [("fp:newsignal", 800.0, "critical")])
     out = format_diff(diff_sessions(a, b))
     assert "new" in out
     assert "inf" not in out.lower()
+
+
+# === verdict coverage (#82): the 3 verdicts not exercised elsewhere ===
+
+
+def test_diff_verdict_regression_new_minor():
+    # A is empty, B has one new MINOR cluster — verdict should NOT be "new critical".
+    a = _summary_with_clusters("hang-a", [])
+    b = _summary_with_clusters("hang-b", [("fp:newminor", 200.0, "minor")])
+    result = diff_sessions(a, b)
+    assert result["verdict"] == "regression: 1 new minor"
+
+
+def test_diff_verdict_improvement_resolved():
+    a = _summary_with_clusters("hang-a", [("fp:wasthere", 500.0, "critical")])
+    b = _summary_with_clusters("hang-b", [])
+    result = diff_sessions(a, b)
+    assert result["verdict"] == "improvement: 1 resolved"
+
+
+def test_diff_verdict_drift_mixed_signs():
+    # Shared fingerprints with one worsening + one improving in B.
+    a = _summary_with_clusters("hang-a", [("fp:up", 500.0, "critical"), ("fp:down", 800.0, "critical")])
+    b = _summary_with_clusters("hang-b", [("fp:up", 800.0, "critical"), ("fp:down", 500.0, "critical")])
+    result = diff_sessions(a, b)
+    assert result["verdict"] == "drift: 1 worsened, 1 improved"
+
+
+# === format_diff render coverage (#82) ===
+
+
+def test_format_diff_renders_new_block():
+    a = _summary_with_clusters("hang-a", [])
+    b = _summary_with_clusters("hang-b", [("fp:fresh", 1500.0, "critical")])
+    out = format_diff(diff_sessions(a, b))
+    assert "New (" in out
+    assert "fp:fresh" in out
+    assert "1500" in out
+
+
+def test_format_diff_renders_resolved_block():
+    a = _summary_with_clusters("hang-a", [("fp:gone", 700.0, "warn")])
+    b = _summary_with_clusters("hang-b", [])
+    out = format_diff(diff_sessions(a, b))
+    assert "Resolved (" in out
+    assert "fp:gone" in out
+
+
+def test_format_diff_renders_drift_block():
+    # 60% bump triggers drift entry.
+    a = _summary_with_clusters("hang-a", [("fp:slow", 500.0, "critical")])
+    b = _summary_with_clusters("hang-b", [("fp:slow", 800.0, "critical")])
+    out = format_diff(diff_sessions(a, b))
+    assert "Drift (" in out
+    assert "fp:slow" in out
+    assert "500" in out
+    assert "800" in out

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -131,3 +131,88 @@ def test_format_diff_version_mismatch_carries_warning():
     b.fingerprint_version = 99
     out = format_diff(diff_sessions(a, b))
     assert "mismatch" in out.lower()
+
+
+# === zero-duration drift handling (#79) ===
+
+
+def _zero_dur_summary(session_id: str, clusters: dict[str, float]) -> "SessionSummary":
+    """Build a SessionSummary with a controlled fingerprint → max_duration_ms map."""
+    from common.hang_pipeline import Cluster, NormalisedEvent, SessionSummary, Severity
+
+    cluster_list = [
+        Cluster(
+            fingerprint=fp,
+            count=1,
+            max_duration_ms=max_dur,
+            total_duration_ms=max_dur,
+            first_delta_ms=0,
+            severity=Severity.CRITICAL if max_dur >= 500 else Severity.MINOR,
+            symbol_or_prefix=fp,
+            sample_event=NormalisedEvent(
+                delta_ms=0,
+                process="p",
+                pid=1,
+                duration_ms=max_dur,
+                severity=Severity.CRITICAL if max_dur >= 500 else Severity.MINOR,
+                symbol=fp,
+                message_prefix=fp,
+                fingerprint=fp,
+            ),
+        )
+        for fp, max_dur in clusters.items()
+    ]
+    return SessionSummary(
+        session_id=session_id,
+        started_at="t",
+        duration_ms=1000,
+        event_count=len(cluster_list),
+        dropped_below_threshold=0,
+        matched_lines=len(cluster_list),
+        total_lines=len(cluster_list),
+        clusters=cluster_list,
+        aggregates={},
+    )
+
+
+def test_diff_zero_to_zero_counts_as_stable():
+    a = _zero_dur_summary("hang-a", {"fp:silent": 0.0})
+    b = _zero_dur_summary("hang-b", {"fp:silent": 0.0})
+    result = diff_sessions(a, b)
+    assert result["stable_count"] == 1
+    assert not result["drift"]
+
+
+def test_diff_zero_to_nonzero_is_drift_with_inf_delta():
+    a = _zero_dur_summary("hang-a", {"fp:newsignal": 0.0})
+    b = _zero_dur_summary("hang-b", {"fp:newsignal": 800.0})
+    result = diff_sessions(a, b)
+    assert len(result["drift"]) == 1
+    assert result["drift"][0]["delta_pct"] == float("inf")
+    assert result["drift"][0]["max_duration_ms_a"] == 0.0
+    assert result["drift"][0]["max_duration_ms_b"] == 800.0
+
+
+def test_diff_nonzero_to_zero_is_drift_with_minus_one_hundred():
+    a = _zero_dur_summary("hang-a", {"fp:fixed": 800.0})
+    b = _zero_dur_summary("hang-b", {"fp:fixed": 0.0})
+    result = diff_sessions(a, b)
+    assert len(result["drift"]) == 1
+    assert result["drift"][0]["delta_pct"] == -100.0
+
+
+def test_diff_nonzero_unchanged_still_uses_threshold():
+    # Regression guard — the new zero-handling branches must not break the standard path.
+    a = _zero_dur_summary("hang-a", {"fp:steady": 500.0})
+    b = _zero_dur_summary("hang-b", {"fp:steady": 505.0})  # 1% drift, well under 20% threshold
+    result = diff_sessions(a, b)
+    assert result["stable_count"] == 1
+    assert not result["drift"]
+
+
+def test_format_diff_renders_inf_delta_as_new():
+    a = _zero_dur_summary("hang-a", {"fp:newsignal": 0.0})
+    b = _zero_dur_summary("hang-b", {"fp:newsignal": 800.0})
+    out = format_diff(diff_sessions(a, b))
+    assert "new" in out
+    assert "inf" not in out.lower()

--- a/tests/test_hang_pipeline.py
+++ b/tests/test_hang_pipeline.py
@@ -167,15 +167,33 @@ def test_bucket_severity_boundaries(ms, expected):
 
 
 def test_compute_fingerprint_prefers_symbol():
-    fp = compute_fingerprint("[ImageDecoder decode:]", "fallback prefix")
-    assert fp.startswith("sym:")
-    assert "ImageDecoder" in fp
+    # Symbol-based fingerprint differs from prefix-based one for the same input.
+    sym_fp = compute_fingerprint("[ImageDecoder decode:]", "fallback prefix")
+    prefix_fp = compute_fingerprint(None, "fallback prefix")
+    assert sym_fp.startswith("fp:")
+    assert sym_fp != prefix_fp
 
 
 def test_compute_fingerprint_falls_back_to_prefix():
     fp = compute_fingerprint(None, "fallback prefix")
-    assert fp.startswith("msg:")
-    assert "fallback prefix" in fp
+    assert fp.startswith("fp:")
+    # Hashed, so the input text is no longer present in the fingerprint.
+    assert "fallback" not in fp
+
+
+def test_compute_fingerprint_is_stable_across_calls():
+    a = compute_fingerprint("[A foo]", "prefix-a")
+    b = compute_fingerprint("[A foo]", "prefix-a")
+    assert a == b
+
+
+def test_compute_fingerprint_avoids_overlap_collision():
+    # Two distinct messages whose first 40 chars are identical must produce
+    # distinct fingerprints — the v1 prefix-based scheme would have collided.
+    shared_head = "Hang detected in MainThread waiting on lock"
+    a = compute_fingerprint(None, shared_head + " a-distinct-suffix")
+    b = compute_fingerprint(None, shared_head + " b-distinct-suffix")
+    assert a != b
 
 
 # === build_normalised_event ===
@@ -195,7 +213,7 @@ def test_build_normalised_event_full():
     assert event.severity == Severity.WARN
     assert event.symbol == "[ImageDecoder decode:]"
     assert event.delta_ms == 12_400
-    assert event.fingerprint.startswith("sym:")
+    assert event.fingerprint.startswith("fp:")
 
 
 def test_build_normalised_event_returns_none_without_duration():

--- a/tests/test_hang_sessions.py
+++ b/tests/test_hang_sessions.py
@@ -346,3 +346,42 @@ def test_load_summary_returns_none_when_missing(store: SessionStore):
     store.claim_worker(meta.session_id, pid=os.getpid())
     store.mark_crashed(meta.session_id)
     assert store.load_summary(meta.session_id) is None
+
+
+# === crashed-session timestamps + duration (#84) ===
+
+
+def test_mark_crashed_records_stopped_timestamps(store: SessionStore):
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    before_ms = int(time.time() * 1000)
+    store.mark_crashed(meta.session_id)
+    after_ms = int(time.time() * 1000)
+    reloaded = store.load_meta(meta.session_id)
+    assert reloaded.stopped_at is not None
+    assert reloaded.stopped_at_ms is not None
+    assert before_ms <= reloaded.stopped_at_ms <= after_ms
+
+
+def test_persist_worker_counters_preserves_crashed_status(store: SessionStore):
+    """A worker that's about to exit shouldn't be able to overwrite its own
+    crashed status back to running when it flushes its line counters."""
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    store.mark_crashed(meta.session_id)
+    store.persist_worker_counters(meta.session_id, {"total": 5, "matched": 0})
+    assert store.load_meta(meta.session_id).status == "crashed"
+
+
+def test_build_summary_uses_stopped_at_ms_for_crashed_session(store: SessionStore):
+    """Duration should reflect the capture window, not the time of inspection."""
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    store.mark_crashed(meta.session_id)
+    # Sleep so "now" diverges from stopped_at_ms — proves the summary doesn't use now.
+    time.sleep(0.1)
+    summary = store.build_summary(meta.session_id)
+    reloaded = store.load_meta(meta.session_id)
+    expected = reloaded.stopped_at_ms - reloaded.started_at_ms
+    # The summary should reflect the recorded window (within ms-level rounding).
+    assert summary.duration_ms == expected

--- a/tests/test_hang_sessions.py
+++ b/tests/test_hang_sessions.py
@@ -315,3 +315,34 @@ def test_read_auto_samples_skips_corrupt_lines(store: SessionStore):
 
     samples = store.read_auto_samples(meta.session_id)
     assert set(samples.keys()) == {"fp:1", "fp:2"}
+
+
+# === crashed-worker recovery (#82) ===
+
+
+def test_mark_crashed_sets_status(store: SessionStore):
+    meta = store.create({})
+    store.mark_crashed(meta.session_id)
+    assert store.load_meta(meta.session_id).status == "crashed"
+
+
+def test_mark_crashed_after_claim_overrides_running(store: SessionStore):
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    store.mark_crashed(meta.session_id)
+    assert store.load_meta(meta.session_id).status == "crashed"
+
+
+def test_mark_crashed_silent_on_missing_session(store: SessionStore):
+    # Worker died before claim_worker; meta may be gone after a TTL prune.
+    store.mark_crashed("hang-19700101-000000-dead")  # never existed
+    # No exception, no side effect; just returns.
+
+
+def test_load_summary_returns_none_when_missing(store: SessionStore):
+    """A session that was created but never reached --stop has no summary.json.
+    load_summary must return None rather than raising."""
+    meta = store.create({})
+    store.claim_worker(meta.session_id, pid=os.getpid())
+    store.mark_crashed(meta.session_id)
+    assert store.load_summary(meta.session_id) is None

--- a/tests/test_hang_sessions.py
+++ b/tests/test_hang_sessions.py
@@ -251,3 +251,67 @@ def test_meta_json_is_valid(store: SessionStore):
     with open(store.session_dir(meta.session_id) / "meta.json") as handle:
         payload = json.load(handle)
     assert payload["args"]["foo"] == "bar"
+
+
+# === auto_samples (JSONL) ===
+
+
+def test_stash_auto_sample_appends_jsonl(store: SessionStore):
+    meta = store.create({})
+    store.stash_auto_sample(meta.session_id, "fp:aaa", {"stack": ["a", "b"], "reason": "ok"})
+    store.stash_auto_sample(meta.session_id, "fp:bbb", {"stack": ["c"], "reason": "ok"})
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert set(samples.keys()) == {"fp:aaa", "fp:bbb"}
+    assert samples["fp:aaa"]["stack"] == ["a", "b"]
+    assert samples["fp:bbb"]["stack"] == ["c"]
+
+
+def test_stash_auto_sample_last_write_wins_per_fingerprint(store: SessionStore):
+    meta = store.create({})
+    store.stash_auto_sample(meta.session_id, "fp:dup", {"reason": "first"})
+    store.stash_auto_sample(meta.session_id, "fp:dup", {"reason": "second"})
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert samples["fp:dup"]["reason"] == "second"
+
+
+def test_read_auto_samples_returns_empty_when_missing(store: SessionStore):
+    meta = store.create({})
+    assert store.read_auto_samples(meta.session_id) == {}
+
+
+def test_concurrent_stash_drops_nothing(store: SessionStore):
+    """Two threads stashing in tight succession must both land — append-only avoids the
+    read-modify-write race the old auto_samples.json had."""
+    import threading
+
+    meta = store.create({})
+    fingerprints = [f"fp:{i:04d}" for i in range(50)]
+    threads = [
+        threading.Thread(
+            target=store.stash_auto_sample,
+            args=(meta.session_id, fp, {"reason": fp}),
+        )
+        for fp in fingerprints
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert set(samples.keys()) == set(fingerprints)
+
+
+def test_read_auto_samples_skips_corrupt_lines(store: SessionStore):
+    meta = store.create({})
+    # Manually corrupt the file with one bad line between two good ones.
+    path = store.session_dir(meta.session_id) / "auto_samples.jsonl"
+    with open(path, "w") as handle:
+        handle.write(json.dumps({"fingerprint": "fp:1", "sample": {"reason": "good"}}) + "\n")
+        handle.write("not-json\n")
+        handle.write(json.dumps({"fingerprint": "fp:2", "sample": {"reason": "good"}}) + "\n")
+
+    samples = store.read_auto_samples(meta.session_id)
+    assert set(samples.keys()) == {"fp:1", "fp:2"}

--- a/tests/test_predicate.py
+++ b/tests/test_predicate.py
@@ -1,0 +1,71 @@
+"""Regression tests for #83 — `--bundle-id` must not narrow the os_log predicate.
+
+The default hang predicate matches RunningBoard / SpringBoard / watchdog events
+that originate outside the target app's process. Pre-#83, passing `--bundle-id`
+ANDed `process == <app>` into the predicate and silently dropped the bulk of
+useful hang signal. This module locks down that the predicate stays simulator-
+global and that bundle filtering is applied post-parse instead.
+"""
+
+import os
+
+import pytest
+
+import hang_watcher
+
+
+# === predicate composition ===
+
+
+def test_default_predicate_includes_runningboard_clause():
+    predicate = hang_watcher._resolve_predicate(None)
+    assert 'com.apple.runningboard' in predicate
+    assert 'Hang detected' in predicate
+
+
+def test_cli_override_takes_precedence():
+    predicate = hang_watcher._resolve_predicate('custom == 1')
+    assert predicate == 'custom == 1'
+
+
+def test_env_var_takes_precedence_over_default(monkeypatch):
+    monkeypatch.setenv('IOS_SIM_HANG_PREDICATE', 'env == 1')
+    assert hang_watcher._resolve_predicate(None) == 'env == 1'
+
+
+def test_predicate_never_narrows_for_bundle_id():
+    """The fix: `_resolve_predicate` no longer accepts a bundle_id arg at all.
+
+    Confirming via signature inspection — adding the param back would resurrect
+    the bug.
+    """
+    import inspect
+
+    params = inspect.signature(hang_watcher._resolve_predicate).parameters
+    assert list(params) == ['predicate'], (
+        f"_resolve_predicate must take only `predicate`, got {list(params)}. "
+        "Adding bundle_id back will re-narrow the predicate and drop RunningBoard events."
+    )
+
+
+# === post-parse bundle filter ===
+
+
+def test_matches_bundle_matches_app_suffix():
+    event = {'process': 'grapla', 'message': 'Hang detected'}
+    assert hang_watcher.matches_bundle(event, 'com.conorluddy.grapla') is True
+
+
+def test_matches_bundle_is_case_insensitive():
+    event = {'process': 'Grapla', 'message': 'x'}
+    assert hang_watcher.matches_bundle(event, 'com.conorluddy.GRAPLA') is True
+
+
+def test_matches_bundle_rejects_other_process():
+    event = {'process': 'runningboardd', 'message': 'x'}
+    assert hang_watcher.matches_bundle(event, 'com.conorluddy.grapla') is False
+
+
+def test_matches_bundle_handles_missing_process():
+    event = {'message': 'x'}
+    assert hang_watcher.matches_bundle(event, 'com.example.app') is False

--- a/tests/test_token_budgets.py
+++ b/tests/test_token_budgets.py
@@ -72,3 +72,46 @@ def test_compress_with_no_budget_returns_l1():
     summary = make_summary()
     out = compress_to_budget(summary, max_tokens=None)
     assert "Drill:" in out
+
+
+# === fixture-stress assertions (#82) ===
+
+
+def test_fixture_covers_all_severity_tiers():
+    """The contract tests are only meaningful if the fixture actually exercises
+    every severity band. Guard against a future fixture regression."""
+    summary = make_summary()
+    severities_present = {c.severity.value for c in summary.clusters}
+    assert severities_present == {"minor", "warn", "critical", "frozen"}
+
+
+def test_fixture_has_at_least_ten_clusters():
+    summary = make_summary()
+    assert len(summary.clusters) >= 10
+
+
+def test_l2_renders_all_aggregate_branches():
+    """L2 formatter has four optional branches (severity histogram, bursts,
+    quiet periods, process distribution). Fixture must populate all four so
+    none are silently skipped."""
+    summary = make_summary()
+    out = format_l2(summary)
+    assert "Severity:" in out
+    assert "Bursts:" in out
+    assert "Quiet periods:" in out
+    assert "Processes:" in out
+
+
+def test_l1_floor_is_meaningful():
+    """L1 should be far enough above zero that the top-N lines actually render."""
+    summary = make_summary()
+    out = format_l1(summary)
+    # Header (~30 tokens) + 3 cluster lines + drill hint should land well above 60.
+    assert estimate_tokens(out) >= 60
+
+
+def test_l2_floor_renders_full_summary():
+    """L2 must include header + every cluster + every aggregate branch — easily 200+ tokens."""
+    summary = make_summary()
+    out = format_l2(summary)
+    assert estimate_tokens(out) >= 200

--- a/tests/test_worker_loop.py
+++ b/tests/test_worker_loop.py
@@ -1,0 +1,264 @@
+"""Worker-loop tests for #84 — EOF detection, bounded restart, crashed marking.
+
+The real worker spawns ``xcrun simctl spawn ... log stream``. These tests
+monkeypatch ``subprocess.Popen`` with a scripted fake so we can drive
+end-of-stream, mid-stream death, and clean shutdown deterministically.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import signal
+from pathlib import Path
+
+import pytest
+
+import hang_watcher
+from common.hang_sessions import SessionStore
+
+
+# === fake subprocess ===
+
+
+class _FakeProc:
+    """Scripted stand-in for ``subprocess.Popen`` of ``log stream``.
+
+    Each call returns a fresh instance. ``script`` is an iterable yielded by a
+    factory so test code can vary behaviour across restart attempts.
+    """
+
+    def __init__(self, lines: list[str], exit_code: int | None = 0):
+        # readline() returns each line in order, then "" forever (EOF).
+        self._lines = list(lines)
+        self.stdout = self
+        self._exit_code = exit_code
+        self._terminated = False
+        self._waited = False
+
+    # --- file-like surface for select / readline ---
+    def fileno(self) -> int:
+        # select() needs a real fileno. Use stderr's — we never actually read
+        # from it; select is monkeypatched at the call site for determinism.
+        return 2
+
+    def readline(self) -> str:
+        if self._lines:
+            return self._lines.pop(0)
+        return ""  # EOF
+
+    # --- Popen surface ---
+    def poll(self) -> int | None:
+        # Once readline has returned EOF the subprocess "exited".
+        return self._exit_code if not self._lines else None
+
+    def terminate(self) -> None:
+        self._terminated = True
+
+    def kill(self) -> None:
+        self._terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._waited = True
+        return self._exit_code if self._exit_code is not None else 0
+
+
+@pytest.fixture
+def patched_select(monkeypatch):
+    """Force ``select.select`` to always report stdout ready so readline runs
+    immediately. The worker's normal 0.25s tick is irrelevant under the fake."""
+    monkeypatch.setattr(
+        hang_watcher.select,
+        "select",
+        lambda rlist, wlist, xlist, timeout: (list(rlist), [], []),
+    )
+
+
+@pytest.fixture
+def patched_sleep(monkeypatch):
+    """Skip the 2s restart backoff so the bounded-restart test isn't slow."""
+    monkeypatch.setattr(hang_watcher.time, "sleep", lambda _: None)
+
+
+@pytest.fixture
+def fast_max_restarts(monkeypatch):
+    """Force a small restart budget so exhaustion tests run in milliseconds."""
+    monkeypatch.setenv("IOS_SIM_HANG_MAX_RESTARTS", "2")
+
+
+@pytest.fixture
+def buster(tmp_path: Path) -> hang_watcher.HangBuster:
+    store = SessionStore(tmp_path / "sessions")
+    return hang_watcher.HangBuster(store=store)
+
+
+def _start_session(buster: hang_watcher.HangBuster, **overrides) -> str:
+    """Create a session row and return its id. Worker isn't spawned — the test
+    invokes ``run_worker`` directly in-process."""
+    args = {
+        "udid": "fake-udid",
+        "min_hang_ms": 100,
+        "bundle_id": None,
+        "predicate": None,
+        "auto_sample": False,
+    }
+    args.update(overrides)
+    meta = buster.store.create(args)
+    return meta.session_id
+
+
+def _read_events(buster: hang_watcher.HangBuster, session_id: str) -> list[dict]:
+    import json as _json
+
+    path = buster.store.events_path(session_id)
+    return [_json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# === EOF triggers restart, exhausts to crashed ===
+
+
+def test_eof_exhausts_restarts_and_marks_crashed(
+    buster, patched_select, patched_sleep, fast_max_restarts, monkeypatch
+):
+    """Every spawn EOFs immediately with no lines — after MAX_RESTARTS the
+    session is marked crashed, not left in stale 'running'."""
+    spawn_count = {"n": 0}
+
+    def _fake_popen(*_args, **_kwargs):
+        spawn_count["n"] += 1
+        return _FakeProc(lines=[], exit_code=1)
+
+    monkeypatch.setattr(hang_watcher.subprocess, "Popen", _fake_popen)
+
+    session_id = _start_session(buster)
+    rc = buster.run_worker(session_id)
+
+    # MAX_RESTARTS=2 → initial spawn + 2 retries = 3 total.
+    assert spawn_count["n"] == 3
+    assert rc == 2
+    meta = buster.store.load_meta(session_id)
+    assert meta.status == "crashed"
+    assert meta.stopped_at_ms is not None
+
+    events = _read_events(buster, session_id)
+    # Expect 1 stream_died after attempt 0, then 1 stream_restart for attempt 1,
+    # stream_died, stream_restart for attempt 2, stream_died (no final restart).
+    died = [e for e in events if e.get("event") == "stream_died"]
+    restarts = [e for e in events if e.get("event") == "stream_restart"]
+    assert len(died) == 3
+    assert len(restarts) == 2
+    assert [r["attempt"] for r in restarts] == [1, 2]
+
+
+def test_eof_then_clean_run_does_not_mark_crashed(
+    buster, patched_select, patched_sleep, fast_max_restarts, monkeypatch
+):
+    """First spawn EOFs immediately; second spawn delivers lines then EOFs.
+    Third spawn (after second EOF) also EOFs. Hits restart budget → crashed.
+    Verifies restart accounting + that lines from attempt 1 are captured."""
+    scripts = [
+        [],  # attempt 0: EOF immediately
+        ["2026-05-23 11:00:00.000 0xa Default 0xa 1 0 grapla: hello\n"],  # attempt 1
+        [],  # attempt 2: EOF
+    ]
+    spawn_log: list[int] = []
+
+    def _fake_popen(*_args, **_kwargs):
+        idx = len(spawn_log)
+        spawn_log.append(idx)
+        return _FakeProc(lines=scripts[idx], exit_code=1)
+
+    monkeypatch.setattr(hang_watcher.subprocess, "Popen", _fake_popen)
+
+    session_id = _start_session(buster)
+    rc = buster.run_worker(session_id)
+
+    assert spawn_log == [0, 1, 2]
+    assert rc == 2  # exhausted -> crashed
+    meta = buster.store.load_meta(session_id)
+    assert meta.status == "crashed"
+    assert meta.extras["line_counters"]["total"] == 1
+    assert meta.extras["line_counters"]["stream_restarts"] == 2
+
+
+# === SIGTERM path is not a crash ===
+
+
+def test_sigterm_during_read_loop_marks_stopped_not_crashed(
+    buster, patched_select, patched_sleep, monkeypatch
+):
+    """SIGTERM mid-stream causes a clean shutdown — stream_ended marker, no
+    stream_died, status stays whatever the parent set (here: still 'running'
+    because no parent stop() ran). Critically: NOT 'crashed'."""
+
+    # Script: deliver one line, then on the next readline call set stop_flag.
+    # We simulate SIGTERM by patching readline to trigger the worker's handler.
+    raised = {"sent": False}
+
+    class _SigtermProc(_FakeProc):
+        def readline(self):
+            if not raised["sent"]:
+                raised["sent"] = True
+                # Send SIGTERM to ourselves — the worker registered a handler.
+                os.kill(os.getpid(), signal.SIGTERM)
+                return "2026-05-23 11:00:00.000 0xa Default 0xa 1 0 grapla: hi\n"
+            return super().readline()
+
+    spawn_count = {"n": 0}
+
+    def _fake_popen(*_args, **_kwargs):
+        spawn_count["n"] += 1
+        return _SigtermProc(lines=["fallback\n"], exit_code=0)
+
+    monkeypatch.setattr(hang_watcher.subprocess, "Popen", _fake_popen)
+
+    session_id = _start_session(buster)
+    rc = buster.run_worker(session_id)
+
+    assert rc == 0  # clean exit
+    meta = buster.store.load_meta(session_id)
+    assert meta.status != "crashed"
+    # Only one spawn — SIGTERM kills the restart loop immediately.
+    assert spawn_count["n"] == 1
+    events = _read_events(buster, session_id)
+    assert any(e.get("event") == "stream_ended" for e in events)
+    assert not any(e.get("event") == "stream_died" for e in events)
+
+
+# === Missing xcrun ===
+
+
+def test_missing_xcrun_marks_crashed_immediately(buster, monkeypatch):
+    """FileNotFoundError on Popen (e.g. xcrun absent in CI) → crashed, no retry."""
+
+    def _fake_popen(*_args, **_kwargs):
+        raise FileNotFoundError("xcrun")
+
+    monkeypatch.setattr(hang_watcher.subprocess, "Popen", _fake_popen)
+
+    session_id = _start_session(buster)
+    rc = buster.run_worker(session_id)
+
+    assert rc == 2
+    assert buster.store.load_meta(session_id).status == "crashed"
+
+
+# === Counters surface restart count ===
+
+
+def test_stream_restarts_counter_in_persisted_meta(
+    buster, patched_select, patched_sleep, fast_max_restarts, monkeypatch
+):
+    """After exhausted restarts, meta.extras.line_counters.stream_restarts
+    matches the highest attempt that ran."""
+
+    def _fake_popen(*_args, **_kwargs):
+        return _FakeProc(lines=[], exit_code=1)
+
+    monkeypatch.setattr(hang_watcher.subprocess, "Popen", _fake_popen)
+
+    session_id = _start_session(buster)
+    buster.run_worker(session_id)
+    meta = buster.store.load_meta(session_id)
+    # MAX_RESTARTS=2 → counter records 2.
+    assert meta.extras["line_counters"]["stream_restarts"] == 2

--- a/tests/test_worker_loop.py
+++ b/tests/test_worker_loop.py
@@ -262,3 +262,174 @@ def test_stream_restarts_counter_in_persisted_meta(
     meta = buster.store.load_meta(session_id)
     # MAX_RESTARTS=2 → counter records 2.
     assert meta.extras["line_counters"]["stream_restarts"] == 2
+
+
+# === #85: raw NDJSON capture ===
+
+
+def test_raw_capture_writes_lines_to_raw_ndjson(buster, patched_select, monkeypatch):
+    """Raw capture dumps every line verbatim to raw.ndjson; events.jsonl
+    receives only synthetic markers (stream_ended on clean stop)."""
+    lines = [
+        '{"eventMessage":"first","process":"grapla"}\n',
+        '{"eventMessage":"second","process":"runningboardd"}\n',
+    ]
+    raised = {"sent": False}
+
+    class _Proc(_FakeProc):
+        def readline(self):
+            # After delivering all real lines, SIGTERM ourselves so the worker
+            # exits cleanly instead of running the restart loop.
+            line = super().readline()
+            if not line and not raised["sent"]:
+                raised["sent"] = True
+                os.kill(os.getpid(), signal.SIGTERM)
+            return line
+
+    monkeypatch.setattr(
+        hang_watcher.subprocess, "Popen", lambda *a, **k: _Proc(lines=list(lines), exit_code=0)
+    )
+
+    session_id = _start_session(buster, raw_capture=True, max_size_mb=10, no_gzip=False)
+    rc = buster.run_worker(session_id)
+
+    assert rc == 0
+    raw_path = buster.store.raw_path(session_id)
+    raw_lines = raw_path.read_text().splitlines()
+    assert raw_lines == [line.rstrip() for line in lines]
+
+
+def test_raw_capture_size_cap_triggers_clean_stop(buster, patched_select, monkeypatch):
+    """When raw.ndjson exceeds max_size_bytes, the worker stops cleanly:
+    writes size_cap_hit event, sets extras.truncated, status=running (not
+    crashed). The parent's stop() will mark stopped."""
+    # 1 KB JSON lines × many → easily exceeds the cap on second write.
+    # Must start with '{' to survive the banner filter in _read_stream_into_raw.
+    big_line = '{"x":"' + "x" * 1014 + '"}\n'
+    lines = [big_line] * 5
+
+    monkeypatch.setattr(
+        hang_watcher.subprocess, "Popen", lambda *a, **k: _FakeProc(lines=lines, exit_code=0)
+    )
+
+    # max_size_mb=0 with a >0 cap intent — use a custom override path.
+    # Simulate a tiny cap by passing max_size_mb=0, then we manually override
+    # the threshold in the test... but the worker code multiplies by 1024*1024.
+    # Easier: write a few-KB cap via monkeypatching the multiplier indirectly —
+    # but cleanest is using max_size_mb=0 means no cap. So instead use 1 MB
+    # cap and feed enough lines (1024 × 1024 lines ≈ 1 GB — too slow).
+    # Trick: monkeypatch _read_stream_into_raw's max_size_bytes computation by
+    # passing the cap directly. Easiest: a tiny override env var? No env exists.
+    # Solution: instantiate _read_stream_into_raw directly with a tiny cap.
+    proc = _FakeProc(lines=lines, exit_code=0)
+    session_id = _start_session(buster, raw_capture=True, max_size_mb=10, no_gzip=True)
+    # The worker has to claim_worker before raw_path is meaningful.
+    buster.store.claim_worker(session_id, pid=os.getpid())
+    raw_handle = open(buster.store.raw_path(session_id), "a", buffering=1)
+    try:
+        cap_state: dict = {"hit": False}
+        counters: dict = {"total": 0}
+        exit_code = buster._read_stream_into_raw(
+            proc=proc,
+            raw_handle=raw_handle,
+            stop_flag={"value": False},
+            counters=counters,
+            max_size_bytes=2048,  # 2 KB — first line over, second pushes past
+            session_id=session_id,
+            cap_state=cap_state,
+        )
+    finally:
+        raw_handle.close()
+
+    assert cap_state["hit"] is True
+    assert counters["total"] >= 1
+    assert buster.store.raw_path(session_id).stat().st_size >= 2048
+
+
+def test_stop_gzips_raw_ndjson(buster, patched_select, monkeypatch, tmp_path):
+    """HangBuster.stop on a raw session gzips raw.ndjson → raw.ndjson.gz,
+    removes the uncompressed file, and records bytes in meta.extras."""
+    session_id = _start_session(buster, raw_capture=True, max_size_mb=10, no_gzip=False)
+    buster.store.claim_worker(session_id, pid=os.getpid())
+    # Write some raw content directly to simulate captured stream.
+    raw_path = buster.store.raw_path(session_id)
+    raw_path.write_text(
+        '{"eventMessage":"a","process":"grapla"}\n'
+        '{"eventMessage":"b","process":"runningboardd"}\n'
+    )
+    # Also persist a line_counters extras so the stop summary doesn't 404.
+    buster.store.persist_worker_counters(session_id, {"total": 2, "stream_restarts": 0})
+
+    # Skip signal_worker — the test doesn't have a real worker pid.
+    monkeypatch.setattr(buster.store, "signal_worker", lambda *a, **k: False)
+
+    out = buster.stop(session_id, json_mode=True)
+    payload = __import__("json").loads(out)
+    assert payload["mode"] == "raw"
+    assert payload["raw_bytes_compressed"] is not None
+
+    gz_path = buster.store.raw_path(session_id, gzipped=True)
+    assert gz_path.exists()
+    assert not raw_path.exists()
+
+    # Round-trip: gunzip and confirm content survived.
+    import gzip as _gz
+
+    with _gz.open(gz_path, "rb") as fp:
+        content = fp.read().decode()
+    assert "grapla" in content and "runningboardd" in content
+
+
+def test_stop_no_gzip_preserves_raw_ndjson(buster, monkeypatch):
+    session_id = _start_session(buster, raw_capture=True, max_size_mb=10, no_gzip=True)
+    buster.store.claim_worker(session_id, pid=os.getpid())
+    raw_path = buster.store.raw_path(session_id)
+    raw_path.write_text("line\n")
+    buster.store.persist_worker_counters(session_id, {"total": 1})
+    monkeypatch.setattr(buster.store, "signal_worker", lambda *a, **k: False)
+
+    buster.stop(session_id)
+    assert raw_path.exists()
+    assert not buster.store.raw_path(session_id, gzipped=True).exists()
+
+
+# === #85: aggregate-cap pruning ===
+
+
+def test_prune_to_aggregate_cap_evicts_oldest_first(buster):
+    """When total bytes exceed cap, oldest session is dropped first until
+    under cap. Newer sessions are preserved."""
+    import time as _time
+
+    # Build 3 sessions with known sizes (~500 bytes each in events.jsonl).
+    ids = []
+    for i in range(3):
+        meta = buster.store.create({"udid": "u", "n": i})
+        buster.store.events_path(meta.session_id).write_text("x" * 500)
+        ids.append(meta.session_id)
+        _time.sleep(0.005)  # ensure distinct started_at_ms
+
+    # Cap at 800 bytes total → must drop at least 2 of 3.
+    deleted = buster.store.prune_to_aggregate_cap(800)
+    assert deleted >= 2
+
+    remaining = {m.session_id for m in buster.store.list_sessions()}
+    # Newest survives.
+    assert ids[2] in remaining
+    # Oldest dropped.
+    assert ids[0] not in remaining
+
+
+def test_prune_to_aggregate_cap_noop_when_under(buster):
+    meta = buster.store.create({"udid": "u"})
+    buster.store.events_path(meta.session_id).write_text("tiny")
+    assert buster.store.prune_to_aggregate_cap(10 * 1024 * 1024) == 0
+    assert meta.session_id in {m.session_id for m in buster.store.list_sessions()}
+
+
+def test_session_total_bytes_sums_all_files(buster):
+    meta = buster.store.create({"udid": "u"})
+    buster.store.events_path(meta.session_id).write_text("aa")  # 2
+    buster.store.raw_path(meta.session_id).write_text("bbb")  # 3
+    # meta.json itself contributes too, so we assert ≥ 5.
+    assert buster.store.session_total_bytes(meta.session_id) >= 5


### PR DESCRIPTION
Combined PR for the four HangBuster review follow-ups plus three live-test discoveries (#83/#84/#85). Each was originally a separate PR (#86, #87, #88, #89); merged into one branch on request. The seven logical commits remain atomic — easy to revert individually if needed.

Closes #79, #80, #81, #82, #83, #84, #85.

## Commits in this PR

| Commit | Closes | Diff |
|---|---|---|
| `fix: append-only JSONL for auto_samples to remove read-modify-write race` | #81 | +109/-13 |
| `fix: handle zero-duration clusters in diff_sessions()` | #79 | +100/-4 |
| `feat: hash compute_fingerprint with sha256, bump FINGERPRINT_VERSION to 2` | #80 | +39/-11 |
| `test: harden HangBuster coverage — crashed-worker, fixture, verdicts` | #82 | +209/-64 |
| `chore: doc sweep — bump script count to 29, add Device State + Simulator Discovery sections` | — | +44/-16 |
| `fix: --bundle-id no longer narrows hang predicate` | #83 | +107/-16 |
| `fix+feat: HangBuster worker EOF detect + bounded auto-restart + capture duration` | #84 | +498/-74 |
| `feat: --raw-capture NDJSON mode + size cap + gzip + aggregate prune` | #85 | +451/-14 |

## #81 — auto_samples JSONL (race fix)

`HangBuster._stash_auto_sample` did a read-modify-write on `auto_samples.json` with no locking; concurrent stashes from a busy worker could drop entries. Switch to append-only `auto_samples.jsonl` mirroring the existing `events.jsonl` discipline (line-buffered + `fsync`).

New `SessionStore.stash_auto_sample()` / `read_auto_samples()` (last-write-wins per fp). Worker delegates — no local I/O.

## #79 — zero-duration drift handling

`diff_sessions()` had a divide-by-zero guard that did a bare `continue`, silently dropping zero-duration clusters from the diff. Worst case: a 0 → 800 ms regression vanished.

Replaced with explicit 4-way branching:

| Case | Result |
|---|---|
| `A == 0, B == 0` | `stable++` |
| `A == 0, B > 0` | drift, `delta_pct = inf` (rendered as `new`) |
| `A > 0, B == 0` | drift, `delta_pct = -100.0` |
| `A > 0, B > 0` | existing percentage logic |

`format_diff` special-cases the `inf` delta so it prints as `new` rather than `+inf%`.

## #80 — sha256 fingerprint, `FINGERPRINT_VERSION=2`

`compute_fingerprint()` returned the raw `sym:<symbol>` / `msg:<message_prefix>` string. Upstream normalisation collapses tokens to `<addr>` / `<pid>` / `<n>` placeholders, so distinct messages with overlapping normalised prefixes collided. Now hashed with sha256[:16] (`fp:<16hex>`).

`Cluster.symbol_or_prefix` already serves as the human-readable label — fingerprint is purely identity. No new `display_prefix` field needed.

`FINGERPRINT_VERSION` bumps 1 → 2. `diff_sessions()` already warns + skips on version mismatch (existing test coverage), so old v1 summaries degrade cleanly.

## #82 — test coverage hardening

**Gap 1: `mark_crashed` + `load_summary→None` (4 new tests)** — the crashed-worker recovery path was entirely untested.

**Gap 2: fixture too soft (5 new tests + fixture rewrite)** — the soft fixture only produced CRITICAL events. L1 hit ~36% of budget, L2 only ~8%. New fixture spans all 4 severities, 12 clusters, 2 processes, populates bursts + quiet periods + process_distribution. All four L2 aggregate branches now actually render.

**Gap 3: verdict + `format_diff` render coverage (6 new tests)** — covers the 3 remaining verdict strings (`new minor` / `improvement: resolved` / `drift: mixed signs`) and the previously-unrendered new / resolved / drift output blocks.

Combined branch unified two near-identical helper functions (`_zero_dur_summary` from #79 and `_summary_with_clusters` from #82) into a single shared `_summary_with_clusters((fp, dur, sev) tuple)` — kept the more flexible form.

## #83 — `--bundle-id` no longer narrows the predicate

Live-test surfaced an unfiled bug: `_resolve_predicate(predicate, bundle_id)` appended `AND (process == <app>)` to the os_log predicate. The default hang predicate matches RunningBoard / SpringBoard / watchdog events that originate **outside** the target app's process, so the AND silently dropped the bulk of useful hang signal.

Verified on Grapla: a 4-minute session with `--bundle-id com.conorluddy.grapla` captured **0 events** while the simulator was actively logging hangs. After removing the AND, an identical workload captures hundreds of RunningBoard events per minute.

Fix: predicate stays simulator-global; bundle filtering applied **post-parse** against the event's process field. Promoted the existing `_matches_bundle` helper to a module-level `matches_bundle()` so the HangBuster worker reuses it. `_resolve_predicate` signature simplified — dropping `bundle_id` arg entirely and locking down via `inspect.signature` regression test so the bug cannot return.

## #84 — Worker EOF detection + bounded auto-restart + capture duration

Live-test surfaced a second bug: `log stream` EOF (or 30s of silence under the old false-positive bail) broke the read loop, wrote a `stream_ended` event, and exited. `SessionStore.persist_worker_counters` then overwrote the status back to `running` — sessions appeared live indefinitely even though the worker had been dead for hours.

Three-part fix:

1. **Crash detection (run_worker rewrite).** Removed the 30s silence bail (a quiet log stream is not a dead one). EOF or `proc.poll() != None` now emits a `stream_died` event with exit_code. `try/finally` wrapping ensures `mark_crashed` runs whenever the worker exits involuntarily. Inner read loop extracted into `_read_stream_into_events` for direct testability.

2. **Bounded auto-restart.** New env var `IOS_SIM_HANG_MAX_RESTARTS` (default 3). Each restart logs a `stream_restart` event with attempt number and a 2s backoff prevents tight respawn loops. `counters` tracks `stream_restarts`; surfaces in summary + `--list-sessions`. SIGTERM during backoff or read loop exits cleanly without restart.

3. **Capture-duration tracking.** `mark_crashed` records `stopped_at`/`stopped_at_ms`. `persist_worker_counters` preserves both CRASHED and STOPPED status. `build_summary` prefers `meta.stopped_at_ms` over `now()` so summaries reflect the capture window. `--list-sessions` surfaces `capture=Xs` and `restarts=N`.

5 new worker-loop tests + 3 new session-store tests use a scripted fake `subprocess.Popen` to drive EOF / mid-stream death / SIGTERM / xcrun-missing scenarios deterministically.

## #85 — `--raw-capture` NDJSON mode + size cap + gzip + aggregate prune

The summarised pipeline is the right shape when you trust the bucketing, but sometimes you want full-fidelity log data and ad-hoc `jq` exploration. `--raw-capture` spawns `log stream --style ndjson` and dumps lines verbatim to `raw.ndjson`, bypassing clustering.

Garbage collection is automatic and layered:

- **Per-session size cap** (`--max-size-mb`, default 10) — worker stops cleanly on cap hit, writes `size_cap_hit` marker, sets `extras.truncated`.
- **Gzip on stop** (skippable with `--no-gzip`) — NDJSON compresses ~15-19× in practice.
- **TTL prune** (existing `IOS_SIM_HANG_SESSION_TTL_HOURS=24`) runs on every `--start`. New aggregate cap `IOS_SIM_HANG_TOTAL_CAP_MB` (default 100) runs alongside, evicting oldest sessions first when total skill state exceeds.

Verified end-to-end on Grapla: a 12-second session captured **737 raw NDJSON lines, 0.96 MB → 0.05 MB gzipped (~19×)**. `jq` queries work directly on the gzipped file:

```
$ zcat raw.ndjson.gz | jq -s 'group_by(.processImagePath) | map({proc: (.[0].processImagePath | split("/") | last), n: length}) | sort_by(-.n) | .[:5]'
[
  {"proc": "runningboardd", "n": 544},
  {"proc": "SpringBoard",   "n":  83},
  {"proc": "mediaremoted",  "n":  39},
  {"proc": "locationd",     "n":  39},
  {"proc": "grapla",        "n":  28}
]
```

That process breakdown is the smoking gun for #83: only 4% of useful hang signal comes from the app process itself.

Implementation notes:

- New CLI: `--raw-capture`, `--max-size-mb`, `--no-gzip`. New env: `IOS_SIM_HANG_TOTAL_CAP_MB`.
- `run_worker` grew a raw-capture branch that reuses the #84 restart/crash machinery. Spawns `log stream --style ndjson`, feeds to `_read_stream_into_raw`, which dumps lines verbatim and bails on size cap.
- Non-JSON banners (`log stream`'s "Filtering the log data ..." first line, `pwuid_r` warnings) are skipped so `jq` consumers get strict NDJSON.
- `_stop_raw_session` gzips via stdlib `gzip` + `shutil.copyfileobj`, removes uncompressed file, records bytes in `meta.extras`. No `summary.json` for raw sessions; `--get-details` points to the file with a `zcat | jq` hint.
- `SessionStore.session_total_bytes` + `prune_to_aggregate_cap` — sum sizes per session, evict oldest first until total ≤ cap. Called from `HangBuster.start()` alongside `prune_expired()`.
- `--list-sessions` surfaces raw size (gzipped if present), truncated flag, capture duration.

7 new tests in `tests/test_worker_loop.py` — raw line writing, size-cap trigger, gzip round-trip + content preservation, `--no-gzip` preserves uncompressed, aggregate-cap eviction order, `session_total_bytes`.

## Test count

Main baseline: **88**. After all seven: **138** (+50).

## Verification

```
ruff check: All checks passed
black --check (scripts): clean
python -m pytest tests/: 138 passed in 0.47s
```

Live end-to-end on Grapla simulator:
- `--bundle-id` no longer narrows predicate (5060+ matched lines vs pre-fix 0).
- `--raw-capture --max-size-mb 1` produced 737 lines / 0.05 MB gzipped, jq-queryable.
- Bounded auto-restart confirmed by fake-subprocess unit tests.

## Compat notes

- `FINGERPRINT_VERSION = 2` writes into new `summary.json` files. Old v1 summaries on disk still load; `--diff` between v1 and v2 fires the existing version-mismatch warning.
- `auto_samples.json` → `auto_samples.jsonl` filename change. No external readers of the old file existed. Old files become inert and TTL-prune naturally.
- `_resolve_predicate(predicate)` signature change (dropped `bundle_id` arg) — internal API only. `--bundle-id` flag still accepted; now filters post-parse.

## Out of scope (deferred from original review)

- Promoting `common/hang_pipeline.py` to a generic `common/log_filters.py` — AHA, wait for a second consumer.
- Temporal-burst overlapping-windows fix (m1 from original review) — defer until someone trips it.
- `_BARE_INT` redaction narrowing (n4) — partially mitigated by #80's hashing absorbing remaining collision risk.
- Streaming summary while session is live — current model: summary only on `--stop`.
- Multi-simulator capture — one session = one UDID.
