### PR TITLE
feat: --auto-sample via xcrun simctl spawn sample (HangBuster PR 1/3)

### DIFF
--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -605,7 +605,9 @@ class HangBuster:
                 e for e in self.store.read_events(session_id) if e.fingerprint == target.fingerprint
             ]
             if resample:
-                target.auto_sample = _attempt_auto_sample(events[0].pid if events else 0)
+                target.auto_sample = _attempt_auto_sample(
+                    meta.args.get("udid", ""), events[0].pid if events else 0
+                )
             if json_mode:
                 from common.hang_pipeline import cluster_to_json
 
@@ -774,6 +776,7 @@ class HangBuster:
                             sampled_fingerprints=sampled_fingerprints,
                             session_id=session_id,
                             session_start_ms=meta.started_at_ms,
+                            udid=udid,
                         )
 
                     if cap_state["hit"]:
@@ -917,6 +920,7 @@ class HangBuster:
         sampled_fingerprints: set[str],
         session_id: str,
         session_start_ms: int,
+        udid: str,
     ) -> int | None:
         """Read lines until EOF / subprocess death / stop request.
 
@@ -970,7 +974,7 @@ class HangBuster:
             if auto_sample and normalised.fingerprint not in sampled_fingerprints:
                 sampled_fingerprints.add(normalised.fingerprint)
                 self._stash_auto_sample(
-                    session_id, normalised, _attempt_auto_sample(normalised.pid)
+                    session_id, normalised, _attempt_auto_sample(udid, normalised.pid)
                 )
             out_handle.write(event_to_jsonl(normalised) + "\n")
         return proc.poll()
@@ -1012,26 +1016,86 @@ class HangBuster:
         self.store.stash_auto_sample(session_id, normalised.fingerprint, sample)
 
 
-def _attempt_auto_sample(pid: int) -> dict:
-    """Soft-import main_thread_sampler and capture a 2s stack sample.
+SAMPLE_DURATION_SECONDS = 1
+SAMPLE_TIMEOUT_SECONDS = 5
 
-    Issue #62 is a soft dependency — graceful degrade with placeholder record
-    when the module isn't present.
+
+def _attempt_auto_sample(udid: str, pid: int) -> dict:
+    """Capture a main-thread stack via ``xcrun simctl spawn <udid> sample``.
+
+    Shells out to the in-simulator ``sample`` binary, which writes a textual
+    main-thread profile to stdout. Short duration keeps the worker hot path
+    responsive; fingerprint dedup at the caller means we sample at most once
+    per unique hang pattern per session.
     """
-    try:
-        from main_thread_sampler import sample_pid  # type: ignore[import-not-found]
-    except ImportError:
-        print(
-            "warning: --auto-sample requested but main_thread_sampler unavailable",
-            file=sys.stderr,
-        )
-        return {"stack": None, "reason": "main_thread_sampler not available"}
+    if not udid:
+        return {
+            "kind": "simctl-sample",
+            "stack": None,
+            "captured_at_ms": int(time.time() * 1000),
+            "symbolicated": False,
+            "reason": "no udid available",
+        }
     if not pid:
-        return {"stack": None, "reason": "no pid available"}
+        return {
+            "kind": "simctl-sample",
+            "stack": None,
+            "captured_at_ms": int(time.time() * 1000),
+            "symbolicated": False,
+            "reason": "no pid available",
+        }
+    cmd = [
+        "xcrun",
+        "simctl",
+        "spawn",
+        udid,
+        "sample",
+        str(pid),
+        str(SAMPLE_DURATION_SECONDS),
+        "-mayDie",
+        "-file",
+        "-",
+    ]
+    captured_at_ms = int(time.time() * 1000)
     try:
-        return {"stack": sample_pid(pid, duration_seconds=2), "reason": "ok"}
-    except Exception as error:
-        return {"stack": None, "reason": f"sample failed: {error}"}
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=SAMPLE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "kind": "simctl-sample",
+            "stack": None,
+            "captured_at_ms": captured_at_ms,
+            "symbolicated": False,
+            "reason": "timeout",
+        }
+    except FileNotFoundError:
+        return {
+            "kind": "simctl-sample",
+            "stack": None,
+            "captured_at_ms": captured_at_ms,
+            "symbolicated": False,
+            "reason": "xcrun not found",
+        }
+    if result.returncode != 0 or not result.stdout.strip():
+        return {
+            "kind": "simctl-sample",
+            "stack": None,
+            "captured_at_ms": captured_at_ms,
+            "symbolicated": False,
+            "reason": (result.stderr.strip() or f"sample exited {result.returncode}")[:200],
+        }
+    return {
+        "kind": "simctl-sample",
+        "stack": result.stdout,
+        "captured_at_ms": captured_at_ms,
+        "symbolicated": False,
+        "reason": None,
+    }
 
 
 # === CLI ===
@@ -1136,7 +1200,7 @@ Environment variables:
     parser.add_argument(
         "--auto-sample",
         action="store_true",
-        help="On hang, capture a main-thread stack via main_thread_sampler (#62)",
+        help="On hang, capture a main-thread stack via `xcrun simctl spawn <udid> sample`",
     )
     parser.add_argument("--top", type=int, dest="top_n", help="Top-N clusters to retain in summary")
     parser.add_argument(

--- a/tests/test_auto_sample.py
+++ b/tests/test_auto_sample.py
@@ -1,0 +1,115 @@
+"""Unit tests for ``_attempt_auto_sample`` — the simctl-sample subprocess wrapper.
+
+The real implementation shells out to ``xcrun simctl spawn <udid> sample <pid>``.
+These tests monkeypatch ``subprocess.run`` so we can drive success, timeout, non-
+zero exit, and missing-pid paths deterministically.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import hang_watcher
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_returns_stack_on_success(monkeypatch):
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeCompleted(stdout="Sampling process 1234...\n  main thread\n  0x100 foo\n")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = hang_watcher._attempt_auto_sample("ABC-123", 1234)
+
+    assert result["kind"] == "simctl-sample"
+    assert result["stack"].startswith("Sampling process 1234")
+    assert result["symbolicated"] is False
+    assert result["reason"] is None
+    assert isinstance(result["captured_at_ms"], int)
+    assert captured["cmd"][:5] == ["xcrun", "simctl", "spawn", "ABC-123", "sample"]
+    assert "1234" in captured["cmd"]
+    assert "-mayDie" in captured["cmd"]
+
+
+def test_missing_udid_short_circuits(monkeypatch):
+    called = {"n": 0}
+
+    def _fake_run(*_a, **_kw):
+        called["n"] += 1
+        return _FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = hang_watcher._attempt_auto_sample("", 1234)
+
+    assert result["stack"] is None
+    assert result["reason"] == "no udid available"
+    assert called["n"] == 0
+
+
+def test_missing_pid_short_circuits(monkeypatch):
+    called = {"n": 0}
+
+    def _fake_run(*_a, **_kw):
+        called["n"] += 1
+        return _FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = hang_watcher._attempt_auto_sample("ABC-123", 0)
+
+    assert result["stack"] is None
+    assert result["reason"] == "no pid available"
+    assert called["n"] == 0
+
+
+def test_timeout_returns_reason(monkeypatch):
+    def _fake_run(cmd, **_kw):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = hang_watcher._attempt_auto_sample("ABC-123", 1234)
+
+    assert result["stack"] is None
+    assert result["reason"] == "timeout"
+    assert result["kind"] == "simctl-sample"
+
+
+def test_nonzero_exit_returns_reason(monkeypatch):
+    def _fake_run(*_a, **_kw):
+        return _FakeCompleted(stdout="", stderr="No such process\n", returncode=1)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = hang_watcher._attempt_auto_sample("ABC-123", 1234)
+
+    assert result["stack"] is None
+    assert "No such process" in result["reason"]
+
+
+def test_empty_stdout_treated_as_failure(monkeypatch):
+    def _fake_run(*_a, **_kw):
+        return _FakeCompleted(stdout="   \n", stderr="", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = hang_watcher._attempt_auto_sample("ABC-123", 1234)
+
+    assert result["stack"] is None
+    assert result["reason"]
+
+
+def test_xcrun_missing_returns_reason(monkeypatch):
+    def _fake_run(*_a, **_kw):
+        raise FileNotFoundError("xcrun")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = hang_watcher._attempt_auto_sample("ABC-123", 1234)
+
+    assert result["stack"] is None
+    assert result["reason"] == "xcrun not found"


### PR DESCRIPTION
## Context

HangBuster's `--auto-sample` flag has been wired end-to-end since #77 — CLI flag, worker hook, fingerprint dedup, `Cluster.auto_sample` slot, and `format_cluster_detail` rendering all exist. The only missing piece was the actual sampler: `_attempt_auto_sample()` soft-imported a `main_thread_sampler` module that doesn't exist in the repo (placeholder for #62), so the flag always degraded to `{stack: None, reason: 'main_thread_sampler not available'}`.

This PR fills in the stub by shelling out to the in-simulator `sample` binary, so each unique hang fingerprint captures a real main-thread stack.

This is **PR 1 of 3** in a stack-enrichment plan:
1. **This PR** — `--auto-sample` backed by `xcrun simctl spawn sample`
2. `--auto-spindump` via `xcrun simctl spawn spindump` (mirrors this shape)
3. `atos` post-processor at `--get-details` time for source-line symbolication

## Changes

- `_attempt_auto_sample` rewritten to shell to `xcrun simctl spawn <udid> sample <pid> 1 -mayDie -file -`. New signature `(udid, pid)`.
- Return dict gains `kind` / `captured_at_ms` / `symbolicated` fields so PR 2 + PR 3 can share the same sidecar shape.
- `udid` threaded through `_read_stream_into_events` and the `--resample` path in `get_details` (both call sites already had it in scope).
- Help text updated to drop the `#62` reference.
- 5s timeout on the subprocess (1s sample + 4s slack) so a stuck `sample` invocation can't hang the worker.

## Tests

7 new units in `tests/test_auto_sample.py` covering: success, timeout, non-zero exit, missing udid, missing pid, empty stdout, `xcrun` not found. All paths return the same dict shape so downstream code stays simple.

```
pytest tests/         145 passed
ruff check            clean
black --check         clean
```

## Verification

- **Unit:** `pytest tests/test_auto_sample.py` — covered.
- **Manual smoke:** boot a sim, launch an app with a known main-thread hang, run `python scripts/hang_watcher.py --start --auto-sample`, reproduce, then `--stop` and `--get-details --cluster 1` should now show a non-empty stack instead of the previous placeholder. (Not run as part of CI — the existing capture path is too sim-coupled to cover in unit tests.)