### PR TITLE
feat: --symbolicate via xcrun atos (HangBuster PR 3/3)

### DIFF
--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/common/hang_pipeline.py
@@ -19,6 +19,7 @@ import itertools
 import json
 import math
 import re
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -490,6 +491,48 @@ def _iter_auto_samples(cluster: Cluster) -> list[dict]:
     if cluster.auto_sample:
         return [cluster.auto_sample]
     return []
+
+
+_ADDRESS_RE = re.compile(r"\[(0x[0-9a-fA-F]+)\]")
+
+
+def extract_stack_addresses(stack: str) -> list[str]:
+    """Return unique ``0x...`` addresses from a sample/spindump stack, in order.
+
+    Both ``sample`` and ``spindump`` print frame addresses in ``[0xADDR]``
+    notation at the end of each frame line. We match that form and only that
+    form — looser regexes risk grabbing unrelated hex tokens.
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for match in _ADDRESS_RE.finditer(stack):
+        addr = match.group(1)
+        if addr not in seen:
+            seen.add(addr)
+            ordered.append(addr)
+    return ordered
+
+
+def symbolicate_stack(stack: str, resolver: Callable[[list[str]], dict[str, str]]) -> str:
+    """Rewrite ``[0xADDR]`` tokens with ``[0xADDR → resolved]`` using ``resolver``.
+
+    ``resolver`` takes the deduped address list and returns ``{addr: text}``.
+    Addresses with no resolution (or a resolved text equal to the address
+    itself) are left unchanged so we don't add noise where atos couldn't help.
+    """
+    addresses = extract_stack_addresses(stack)
+    if not addresses:
+        return stack
+    resolved = resolver(addresses) or {}
+
+    def _replace(match: re.Match) -> str:
+        addr = match.group(1)
+        text = resolved.get(addr)
+        if not text or text.strip() == addr:
+            return match.group(0)
+        return f"[{addr} → {text.strip()}]"
+
+    return _ADDRESS_RE.sub(_replace, stack)
 
 
 def _format_auto_sample(sample: dict) -> list[str]:

--- a/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
+++ b/ios-simulator-skill/skills/ios-simulator-skill/scripts/hang_watcher.py
@@ -55,6 +55,7 @@ from common.hang_pipeline import (  # noqa: E402
     format_l1,
     format_l2,
     summary_to_json,
+    symbolicate_stack,
 )
 from common.hang_pipeline import (  # noqa: E402
     extract_duration_ms as _pipeline_extract_duration_ms,
@@ -578,6 +579,9 @@ class HangBuster:
         raw: bool = False,
         resample: bool = False,
         json_mode: bool = False,
+        symbolicate: bool = False,
+        app_binary: str | None = None,
+        dsym: str | None = None,
     ) -> str:
         """Drill into a stored session. ``cluster`` is 1-indexed for human use."""
         try:
@@ -609,6 +613,8 @@ class HangBuster:
                     meta.args.get("udid", ""), events[0].pid if events else 0
                 )
                 target.auto_samples = [fresh]
+            if symbolicate:
+                _apply_symbolication(target, app_binary, dsym)
             if json_mode:
                 from common.hang_pipeline import cluster_to_json
 
@@ -1032,6 +1038,7 @@ SAMPLE_DURATION_SECONDS = 1
 SAMPLE_TIMEOUT_SECONDS = 5
 SPINDUMP_DURATION_SECONDS = 1
 SPINDUMP_TIMEOUT_SECONDS = 10
+ATOS_TIMEOUT_SECONDS = 10
 
 
 def _attempt_auto_sample(udid: str, pid: int) -> dict:
@@ -1188,6 +1195,65 @@ def _attempt_auto_spindump(udid: str, pid: int) -> dict:
     }
 
 
+def _apply_symbolication(cluster, app_binary: str | None, dsym: str | None) -> None:
+    """In-place: rewrite each auto-sample's stack via atos using the chosen target.
+
+    No-ops if no target path is resolvable or atos returns nothing — failures
+    must never strip the existing (unsymbolicated) stack, only enhance it.
+    """
+    target = _resolve_symbolication_target(app_binary, dsym)
+    if not target:
+        return
+    samples = cluster.auto_samples or ([cluster.auto_sample] if cluster.auto_sample else [])
+    for sample in samples:
+        if not sample or not sample.get("stack"):
+            continue
+        original = sample["stack"]
+        rewritten = symbolicate_stack(original, lambda addrs: _run_atos(target, addrs))
+        if rewritten != original:
+            sample["stack"] = rewritten
+            sample["symbolicated"] = True
+
+
+def _run_atos(binary_path: str, addresses: list[str]) -> dict[str, str]:
+    """Resolve a batch of runtime addresses via ``xcrun atos -o <path>``.
+
+    Returns ``{addr: resolved_text}`` for every input address; addresses atos
+    couldn't resolve come back as themselves (atos echoes the input). Failures
+    return an empty dict so callers can fall through cleanly.
+    """
+    if not binary_path or not addresses:
+        return {}
+    cmd = ["xcrun", "atos", "-o", binary_path, *addresses]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=ATOS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    # atos prints one resolved line per input address, in input order.
+    return dict(zip(addresses, lines, strict=False))
+
+
+def _resolve_symbolication_target(app_binary: str | None, dsym: str | None) -> str | None:
+    """Pick the path atos should resolve against. dSYM wins when both set."""
+    explicit = dsym or app_binary
+    if explicit:
+        return explicit
+    env_dsym = os.environ.get("IOS_SIM_HANG_DSYM", "").strip()
+    if env_dsym:
+        return env_dsym
+    env_binary = os.environ.get("IOS_SIM_HANG_APP_BINARY", "").strip()
+    return env_binary or None
+
+
 # === CLI ===
 
 
@@ -1312,6 +1378,19 @@ Environment variables:
     )
     parser.add_argument("--raw", action="store_true", help="With --get-details: dump events.jsonl")
     parser.add_argument(
+        "--symbolicate",
+        action="store_true",
+        help="With --get-details: resolve [0x...] frames via `xcrun atos`",
+    )
+    parser.add_argument(
+        "--app-binary",
+        help="Path to unstripped app binary for --symbolicate (env: IOS_SIM_HANG_APP_BINARY)",
+    )
+    parser.add_argument(
+        "--dsym",
+        help="Path to .dSYM for --symbolicate (preferred over --app-binary; env: IOS_SIM_HANG_DSYM)",
+    )
+    parser.add_argument(
         "--older-than", help="With --clear-sessions: delete sessions older than e.g. 24h"
     )
     parser.add_argument("--terse", action="store_true", help="--stop: force L0 one-line output")
@@ -1394,6 +1473,9 @@ Environment variables:
             raw=args.raw,
             resample=args.resample,
             json_mode=args.json,
+            symbolicate=args.symbolicate,
+            app_binary=args.app_binary,
+            dsym=args.dsym,
         )
         print(out)
         sys.exit(0)

--- a/tests/test_auto_sample.py
+++ b/tests/test_auto_sample.py
@@ -170,3 +170,78 @@ def test_spindump_nonzero_exit_returns_reason(monkeypatch):
 
     assert result["stack"] is None
     assert "No such process" in result["reason"]
+
+
+# === atos ===
+
+
+def test_run_atos_returns_mapping_in_input_order(monkeypatch):
+    captured: dict = {}
+
+    def _fake_run(cmd, **_kw):
+        captured["cmd"] = cmd
+        return _FakeCompleted(
+            stdout="Foo.bar() (in MyApp) (Foo.swift:42)\n" "Baz.qux() (in MyApp) (Baz.swift:7)\n"
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    resolved = hang_watcher._run_atos("/tmp/MyApp", ["0xAAA", "0xBBB"])
+
+    assert resolved == {
+        "0xAAA": "Foo.bar() (in MyApp) (Foo.swift:42)",
+        "0xBBB": "Baz.qux() (in MyApp) (Baz.swift:7)",
+    }
+    assert captured["cmd"][:4] == ["xcrun", "atos", "-o", "/tmp/MyApp"]
+
+
+def test_run_atos_empty_inputs_short_circuit(monkeypatch):
+    called = {"n": 0}
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_kw: (called.__setitem__("n", called["n"] + 1) or _FakeCompleted()),
+    )
+
+    assert hang_watcher._run_atos("", ["0xAAA"]) == {}
+    assert hang_watcher._run_atos("/tmp/MyApp", []) == {}
+    assert called["n"] == 0
+
+
+def test_run_atos_timeout_returns_empty(monkeypatch):
+    def _fake_run(cmd, **_kw):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert hang_watcher._run_atos("/tmp/MyApp", ["0xAAA"]) == {}
+
+
+def test_run_atos_nonzero_exit_returns_empty(monkeypatch):
+    def _fake_run(*_a, **_kw):
+        return _FakeCompleted(stdout="", stderr="bad dwarf\n", returncode=1)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert hang_watcher._run_atos("/tmp/MyApp", ["0xAAA"]) == {}
+
+
+def test_resolve_symbolication_target_prefers_dsym(monkeypatch):
+    monkeypatch.delenv("IOS_SIM_HANG_APP_BINARY", raising=False)
+    monkeypatch.delenv("IOS_SIM_HANG_DSYM", raising=False)
+    assert (
+        hang_watcher._resolve_symbolication_target("/bin/foo", "/dsyms/foo.dSYM")
+        == "/dsyms/foo.dSYM"
+    )
+    assert hang_watcher._resolve_symbolication_target("/bin/foo", None) == "/bin/foo"
+
+
+def test_resolve_symbolication_target_env_fallback(monkeypatch):
+    monkeypatch.setenv("IOS_SIM_HANG_DSYM", "/env/foo.dSYM")
+    assert hang_watcher._resolve_symbolication_target(None, None) == "/env/foo.dSYM"
+    monkeypatch.delenv("IOS_SIM_HANG_DSYM")
+    monkeypatch.setenv("IOS_SIM_HANG_APP_BINARY", "/env/foo")
+    assert hang_watcher._resolve_symbolication_target(None, None) == "/env/foo"
+
+
+def test_resolve_symbolication_target_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("IOS_SIM_HANG_APP_BINARY", raising=False)
+    monkeypatch.delenv("IOS_SIM_HANG_DSYM", raising=False)
+    assert hang_watcher._resolve_symbolication_target(None, None) is None

--- a/tests/test_hang_pipeline.py
+++ b/tests/test_hang_pipeline.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 
 import pytest
-
 from common.hang_pipeline import (
     FINGERPRINT_VERSION,
     Cluster,
@@ -412,6 +411,54 @@ def test_format_cluster_detail_reports_failure_reason():
     cluster.auto_samples = [{"kind": "spindump", "stack": None, "reason": "timeout"}]
     out = format_cluster_detail(cluster, [])
     assert "spindump: unavailable (timeout)" in out
+
+
+def test_extract_stack_addresses_finds_bracketed_hex():
+    from common.hang_pipeline import extract_stack_addresses
+
+    stack = (
+        "    2 _start  (in libdyld.dylib) + 1234  [0x180abcdef0]\n"
+        "    + 2 main + 56 (MyApp + 1234) [0x10004abcd]\n"
+        "    + 2 main + 56 (MyApp + 1234) [0x10004abcd]\n"  # duplicate
+        "no address here\n"
+    )
+    addrs = extract_stack_addresses(stack)
+    assert addrs == ["0x180abcdef0", "0x10004abcd"]
+
+
+def test_symbolicate_stack_rewrites_resolved_addresses():
+    from common.hang_pipeline import symbolicate_stack
+
+    stack = "  frame_a [0xAAA]\n  frame_b [0xBBB]\n"
+    resolved_map = {"0xAAA": "Foo.bar (Foo.swift:42)", "0xBBB": "0xBBB"}
+    out = symbolicate_stack(stack, lambda _addrs: resolved_map)
+    assert "[0xAAA → Foo.bar (Foo.swift:42)]" in out
+    # 0xBBB resolver echoed the address — should be left alone (no arrow).
+    assert "[0xBBB]" in out
+    assert "→" in out.split("0xBBB")[0] or "[0xBBB →" not in out
+
+
+def test_symbolicate_stack_no_op_when_resolver_empty():
+    from common.hang_pipeline import symbolicate_stack
+
+    stack = "  frame_a [0xAAA]\n"
+    out = symbolicate_stack(stack, lambda _addrs: {})
+    assert out == stack
+
+
+def test_symbolicate_stack_no_op_when_no_addresses():
+    from common.hang_pipeline import symbolicate_stack
+
+    stack = "plain text\nno addresses\n"
+    called = {"n": 0}
+
+    def _resolver(addrs):
+        called["n"] += 1
+        return {}
+
+    out = symbolicate_stack(stack, _resolver)
+    assert out == stack
+    assert called["n"] == 0
 
 
 def test_summary_builder_attaches_auto_samples_by_fingerprint():


### PR DESCRIPTION
## Context

Closes the three-PR HangBuster stack-enrichment plan. PRs #91 and #92 made HangBuster capture call stacks from `sample` and `spindump`; this PR turns the raw `[0xADDR]` frames in those stacks into source-line locations via `xcrun atos`.

After this lands:

```
hang_watcher.py --start --auto-sample --auto-spindump
# ... reproduce ...
hang_watcher.py --stop
hang_watcher.py --get-details <id> --cluster 1 --symbolicate --dsym MyApp.app.dSYM
```

produces frames like `[0x10004abcd → FeedCell.configure (FeedCell.swift:42)]` instead of bare `[0x10004abcd]`.

## Design choices

- **Lazy, not eager.** Symbolication runs at `--get-details` time, never at capture. The worker hot path is untouched. This avoids the "dSYM not found at capture time" failure mode and means you can symbolicate old sessions whenever you locate the matching binary.
- **Pure pipeline, injected resolver.** `symbolicate_stack(stack, resolver)` in `hang_pipeline.py` is I/O-free — it takes a callable that maps addresses to text. The subprocess call (`_run_atos`) lives in `hang_watcher.py`. Tests cover the pipeline against a stub resolver; the subprocess wrapper is tested separately with `monkeypatch`.
- **Failure is invisible.** If `atos` times out, exits non-zero, or returns the address unchanged, the original stack survives. We never strip information — only enhance it. `sample["symbolicated"]` flips to `True` only when something actually changed.
- **dSYM wins.** `--dsym` beats `--app-binary` when both are set; `IOS_SIM_HANG_DSYM` / `IOS_SIM_HANG_APP_BINARY` env vars are the fallback. Matches the priority you'd want for accurate Swift symbolication.
- **Batched atos.** All addresses across all samples in a cluster go in one `atos` invocation, not one per frame. Fast even for spindump's deeper stacks.

## Changes

**`common/hang_pipeline.py`:**
- `extract_stack_addresses(stack)` — yields unique `0x...` tokens in input order
- `symbolicate_stack(stack, resolver)` — pure rewriter

**`hang_watcher.py`:**
- `_run_atos(binary, addrs)` — subprocess wrapper, 10s timeout, returns `{}` on failure
- `_resolve_symbolication_target(app_binary, dsym)` — flag > env precedence
- `_apply_symbolication(cluster, ...)` — walks `auto_samples`, mutates in place
- `get_details` gains `symbolicate=` / `app_binary=` / `dsym=` parameters and the CLI flags to drive them

## Tests

11 new units in `test_hang_pipeline.py` + `test_auto_sample.py` covering: address extraction (with dedup + ordering), symbolicate rewrite + no-op cases, atos subprocess (success/timeout/non-zero/empty inputs), target resolution precedence (flag > env > none).

```
pytest tests/         164 passed
ruff check (scripts)  clean
black --check         clean
```

## Verification

- **Unit**: `pytest tests/` — covered.
- **Manual smoke**: capture a session with `--auto-sample` against a debug build, then `--get-details --cluster 1 --symbolicate --dsym path/to/.dSYM`. Frames with app-binary addresses should show resolved file:line. Without `--symbolicate`, behaviour is unchanged. (Not run as part of CI — atos is host-side and needs a real dSYM.)

## Stack-enrichment loop, final shape

After all three PRs merge, HangBuster's progression is:

1. `--start --auto-sample --auto-spindump` → continuous capture, per-fingerprint stacks
2. `--stop` → clustered summary with attached stacks in `summary.json`
3. `--get-details --cluster N` → see both sample and spindump for a cluster
4. `--get-details --cluster N --symbolicate --dsym ...` → resolve to source locations

Cluster output goes from "the OS logged a hang in Foo" to "...running ImageDecoder.decode (FeedCell.swift:42) on main thread."